### PR TITLE
fix: define brevo mailer (MAIL_MAILER=brevo)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,8 @@ SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
 # Mail: Laravel SMTP (default mailer). Production example: Brevo — verify sender/domain in Brevo first.
-# MAIL_HOST=smtp-relay.brevo.com
+# Option A: MAIL_MAILER=smtp and MAIL_HOST=smtp-relay.brevo.com
+# Option B: MAIL_MAILER=brevo (same MAIL_*; default host is smtp-relay.brevo.com if MAIL_HOST unset)
 # MAIL_PORT=587
 # MAIL_USERNAME=your-brevo-login-email@example.com
 # MAIL_PASSWORD=your-smtp-key-from-brevo-dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
+- Define `mail.mailers.brevo` in `config/mail.php` so `MAIL_MAILER=brevo` works (Brevo SMTP; same `MAIL_*` as `smtp`, default host `smtp-relay.brevo.com`).
 - Add `sessions` and `cache` / `cache_locks` migrations for apps using `SESSION_DRIVER=database` and database-backed cache (Laravel 13 default-style tables).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ Transactional mail (contact form confirmations, `php artisan email:test`, schedu
 
 **Production (Brevo SMTP):** In the Brevo dashboard, create an SMTP key and verify your sending domain or sender. Example `.env` values:
 
-- `MAIL_MAILER=smtp`
-- `MAIL_HOST=smtp-relay.brevo.com`
+- `MAIL_MAILER=smtp` **or** `MAIL_MAILER=brevo` (alias in `config/mail.php`; same `MAIL_*` keys — if you use `brevo` and omit `MAIL_HOST`, it defaults to `smtp-relay.brevo.com`)
+- `MAIL_HOST=smtp-relay.brevo.com` (optional when using `MAIL_MAILER=brevo`; required for explicit host with `smtp`)
 - `MAIL_PORT=587`
 - `MAIL_ENCRYPTION=tls`
 - `MAIL_USERNAME` — usually your Brevo account email (exact value is shown in Brevo SMTP settings)

--- a/config/mail.php
+++ b/config/mail.php
@@ -45,6 +45,21 @@ return [
             'auth_mode' => null,
         ],
 
+        /*
+        | Same as `smtp` but defaults host to Brevo when MAIL_HOST is unset.
+        | Use MAIL_MAILER=brevo with MAIL_USERNAME / MAIL_PASSWORD (SMTP key) from Brevo.
+        */
+        'brevo' => [
+            'transport' => 'smtp',
+            'host' => env('MAIL_HOST', 'smtp-relay.brevo.com'),
+            'port' => env('MAIL_PORT', 587),
+            'encryption' => env('MAIL_ENCRYPTION', 'tls'),
+            'username' => env('MAIL_USERNAME'),
+            'password' => env('MAIL_PASSWORD'),
+            'timeout' => null,
+            'auth_mode' => null,
+        ],
+
         'ses' => [
             'transport' => 'ses',
         ],

--- a/docs/tickets/2026-04-07-define-mailer-brevo.md
+++ b/docs/tickets/2026-04-07-define-mailer-brevo.md
@@ -1,0 +1,21 @@
+## Title
+Define `brevo` mailer in `config/mail.php`
+
+## Summary
+Deployments using `MAIL_MAILER=brevo` throw `InvalidArgumentException: Mailer [brevo] is not defined` because only `smtp` and other built-in names exist. Add a `brevo` SMTP mailer (Brevo-compatible defaults).
+
+## Background / Context
+- **Steps:** Set `MAIL_MAILER=brevo` with Brevo `MAIL_*` credentials; submit contact form.
+- **Observed:** Exception; contact row is saved but mail fails.
+- **Expected:** Mail sends via Brevo SMTP.
+
+## Requirements
+- [ ] `config/mail.php` defines `mailers.brevo` as SMTP using `MAIL_*` (default host `smtp-relay.brevo.com` when `MAIL_HOST` unset).
+- [ ] `.env.example` / README note optional `MAIL_MAILER=brevo`.
+
+## Testing
+- PHPUnit: assert `config('mail.mailers.brevo.transport')` is `smtp`.
+- Manual: `MAIL_MAILER=brevo` + valid Brevo credentials; contact form sends.
+
+## Impact / Risks
+- Low; additive config only.

--- a/tests/Unit/MailConfigTest.php
+++ b/tests/Unit/MailConfigTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class MailConfigTest extends TestCase
+{
+    public function test_brevo_mailer_is_defined_as_smtp(): void
+    {
+        $brevo = config('mail.mailers.brevo');
+        $this->assertIsArray($brevo);
+        $this->assertSame('smtp', $brevo['transport']);
+        $this->assertArrayHasKey('host', $brevo);
+    }
+}


### PR DESCRIPTION
## Summary
Resolves `Mailer [brevo] is not defined` when production uses `MAIL_MAILER=brevo`.

## Changes
- `config/mail.php`: add `brevo` SMTP mailer (same `MAIL_*` as `smtp`, default host `smtp-relay.brevo.com`).
- README, `.env.example`, CHANGELOG; ticket + unit test.

## Roadmap
N/A (config bugfix).

## Tests
`ddev exec php artisan test` — all pass.

Made with [Cursor](https://cursor.com)