### PR TITLE
feat: Brevo mail via HTTP API (Issue Forge parity)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,13 +23,15 @@ QUEUE_CONNECTION=sync
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
-# Mail: Laravel SMTP (default mailer). Production example: Brevo — verify sender/domain in Brevo first.
-# Option A: MAIL_MAILER=smtp and MAIL_HOST=smtp-relay.brevo.com
-# Option B: MAIL_MAILER=brevo (same MAIL_*; default host is smtp-relay.brevo.com if MAIL_HOST unset)
+# Mail: default is SMTP (local Mailpit). Production — Brevo like Issue Forge: HTTP API (no SMTP ports).
+# Brevo API: MAIL_MAILER=brevo and BREVO_API_KEY= (from Brevo dashboard; transactional key)
+# Classic SMTP: MAIL_MAILER=smtp, e.g. Brevo relay:
+# MAIL_HOST=smtp-relay.brevo.com
 # MAIL_PORT=587
-# MAIL_USERNAME=your-brevo-login-email@example.com
-# MAIL_PASSWORD=your-smtp-key-from-brevo-dashboard
+# MAIL_USERNAME=your-brevo-smtp-login
+# MAIL_PASSWORD=your-smtp-key
 # MAIL_ENCRYPTION=tls
+BREVO_API_KEY=
 MAIL_MAILER=smtp
 MAIL_HOST=127.0.0.1
 MAIL_PORT=1025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,17 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
-- **SMTP transactional mail:** contact form and `php artisan email:test` use Laravel’s configured mailer (`MAIL_*`) via `App\Services\TransactionalMailService` instead of the SendGrid HTTP API. Operators can use **Brevo** (or any SMTP provider); see README and `.env.example`. Removed `sendgrid/sendgrid` and `symfony/sendgrid-mailer`.
+- **SMTP / Brevo API transactional mail:** contact form and `php artisan email:test` use Laravel’s configured mailer via `App\Services\TransactionalMailService`. **`MAIL_MAILER=brevo`** uses `getbrevo/brevo-php` and `App\Mail\Transport\BrevoApiTransport` (same pattern as Issue Forge; `BREVO_API_KEY`). **`MAIL_MAILER=smtp`** uses `MAIL_*` for any SMTP relay. See README and `.env.example`. Removed `sendgrid/sendgrid` and `symfony/sendgrid-mailer`.
 - **Cookie consent:** first-party UI (dark-themed bottom strip + preference modal with categories, Cookiebot-style actions) stores analytics preference in the browser and loads Matomo only after opt-in. Footer link reopens settings. Cookiebot dependency removed.
 - **Sentry** (`sentry/sentry-laravel`): unhandled exceptions can be reported to Sentry when `SENTRY_LARAVEL_DSN` is set in `.env`. Configuration in `config/sentry.php`; exception handling wired in `bootstrap/app.php`. Use `php artisan sentry:test` to verify after configuring the DSN.
 
 ### Changed
 
 - Matomo: frontend tracker now uses the self-hosted instance at `analytics.kadsuno.com` (replaces Matomo Cloud). Toggle with `MATOMO_ENABLED`; tracker URL and site id via `MATOMO_TRACKER_URL` and `MATOMO_SITE_ID` (`config/matomo.php`).
+- **Brevo (`MAIL_MAILER=brevo`):** uses the **Brevo HTTP API** (`getbrevo/brevo-php`, `App\Mail\Transport\BrevoApiTransport`, `Mail::extend` in `AppServiceProvider`) — same approach as [Issue Forge](https://github.com/Kadsuno/issue-forge). Set **`BREVO_API_KEY`** (not SMTP). For classic SMTP to any provider, keep **`MAIL_MAILER=smtp`** and `MAIL_*`.
 
 ### Fixed
 
-- Define `mail.mailers.brevo` in `config/mail.php` so `MAIL_MAILER=brevo` works (Brevo SMTP; same `MAIL_*` as `smtp`, default host `smtp-relay.brevo.com`).
 - Add `sessions` and `cache` / `cache_locks` migrations for apps using `SESSION_DRIVER=database` and database-backed cache (Laravel 13 default-style tables).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Smash Up Randomizer supports:
 
 - Random assignment of factions to players (player count, include/exclude factions via the **home** page shuffle modal → `POST /shuffle/result`)
 - Browsing all factions and per-faction detail pages
-- Contact form with email delivery (Laravel SMTP, e.g. Brevo)
+- Contact form with email delivery (Laravel mail: SMTP or Brevo API)
 - Admin area for managing deck data (authenticated users)
 - XML sitemap (`/sitemap`) via `spatie/laravel-sitemap`
 - Dark-themed, responsive frontend (Bootstrap 5, Vite, Blade)
@@ -86,7 +86,7 @@ Local stack is defined in `.ddev/config.yaml` (PHP 8.3, MariaDB 10.4, Node 18, n
     ddev exec php artisan key:generate
     ```
 
-6. Configure `.env` (database credentials are usually pre-filled for DDEV; set `MAIL_*` for outbound mail — local dev often uses Mailpit on `127.0.0.1:1025`; production can use **Brevo SMTP** — see **Email** below). Optional **Matomo** (public site analytics): `MATOMO_ENABLED` (default `true`), `MATOMO_TRACKER_URL` (default `https://analytics.kadsuno.com`), `MATOMO_SITE_ID` (default `1`) — see `config/matomo.php`. Set `MATOMO_ENABLED=false` locally if you do not want the tracker script loaded. Optional **Sentry** (error monitoring): set `SENTRY_LARAVEL_DSN` from your Sentry project (leave empty to disable). See `config/sentry.php` and run `php artisan sentry:test` after configuring. For full stack trace *argument* values in PHP error reports, set `zend.exception_ignore_args=Off` in `php.ini` (server-level).
+6. Configure `.env` (database credentials are usually pre-filled for DDEV; set mail for outbound email — local dev often uses Mailpit on `127.0.0.1:1025`; production can use **`MAIL_MAILER=brevo`** + `BREVO_API_KEY` (Issue Forge–style) or **SMTP** — see **Email** below). Optional **Matomo** (public site analytics): `MATOMO_ENABLED` (default `true`), `MATOMO_TRACKER_URL` (default `https://analytics.kadsuno.com`), `MATOMO_SITE_ID` (default `1`) — see `config/matomo.php`. Set `MATOMO_ENABLED=false` locally if you do not want the tracker script loaded. Optional **Sentry** (error monitoring): set `SENTRY_LARAVEL_DSN` from your Sentry project (leave empty to disable). See `config/sentry.php` and run `php artisan sentry:test` after configuring. For full stack trace *argument* values in PHP error reports, set `zend.exception_ignore_args=Off` in `php.ini` (server-level).
 
 7. Migrations:
 
@@ -153,19 +153,22 @@ Blade under `resources/views/`: `start/`, `shuffle/`, `decks/`, `frontend/`, `ba
 
 ### Email
 
-Transactional mail (contact form confirmations, `php artisan email:test`, scheduled daily test) uses Laravel’s default mailer via `App\Services\TransactionalMailService` and `config/mail.php` (`MAIL_*`).
+Transactional mail (contact form confirmations, `php artisan email:test`, scheduled daily test) uses Laravel’s default mailer via `App\Services\TransactionalMailService` and `config/mail.php`.
 
-**Production (Brevo SMTP):** In the Brevo dashboard, create an SMTP key and verify your sending domain or sender. Example `.env` values:
+**Production — Brevo via HTTP API (same as [Issue Forge](https://github.com/Kadsuno/issue-forge)):** Uses `getbrevo/brevo-php` and `App\Mail\Transport\BrevoApiTransport` when `MAIL_MAILER=brevo`. Create an **API key** in Brevo (transactional). Example:
 
-- `MAIL_MAILER=smtp` **or** `MAIL_MAILER=brevo` (alias in `config/mail.php`; same `MAIL_*` keys — if you use `brevo` and omit `MAIL_HOST`, it defaults to `smtp-relay.brevo.com`)
-- `MAIL_HOST=smtp-relay.brevo.com` (optional when using `MAIL_MAILER=brevo`; required for explicit host with `smtp`)
-- `MAIL_PORT=587`
-- `MAIL_ENCRYPTION=tls`
-- `MAIL_USERNAME` — usually your Brevo account email (exact value is shown in Brevo SMTP settings)
-- `MAIL_PASSWORD` — SMTP key from Brevo (not your login password)
+- `MAIL_MAILER=brevo`
+- `BREVO_API_KEY=xkeysib-...` (or your Brevo v3 API key)
 - `MAIL_FROM_ADDRESS` / `MAIL_FROM_NAME` — must match a verified sender in Brevo
 
-**Local:** Point `MAIL_HOST` / `MAIL_PORT` at your mail catcher (e.g. Mailpit on `127.0.0.1:1025` with `MAIL_ENCRYPTION=null`).
+This uses **HTTPS** to Brevo’s API (no outbound SMTP ports), which avoids many host firewalls that block port 587.
+
+**Production — classic SMTP:** Use any provider (including Brevo SMTP relay) with:
+
+- `MAIL_MAILER=smtp`
+- `MAIL_HOST`, `MAIL_PORT`, `MAIL_ENCRYPTION`, `MAIL_USERNAME`, `MAIL_PASSWORD`, plus `MAIL_FROM_*` as required by your provider.
+
+**Local:** Use `MAIL_MAILER=smtp` and point `MAIL_HOST` / `MAIL_PORT` at a mail catcher (e.g. Mailpit on `127.0.0.1:1025` with `MAIL_ENCRYPTION=null`). For `brevo` + real API key, emails send via Brevo (use a test recipient or a separate Brevo sandbox if available).
 
 Other Symfony mail transports remain available in `composer.json` if you switch `MAIL_MAILER` (Mailgun, Postmark, etc.).
 

--- a/app/Mail/Transport/BrevoApiTransport.php
+++ b/app/Mail/Transport/BrevoApiTransport.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail\Transport;
+
+use Brevo\Client\Api\TransactionalEmailsApi;
+use Brevo\Client\Configuration;
+use Brevo\Client\Model\SendSmtpEmail;
+use GuzzleHttp\Client;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\MessageConverter;
+
+final class BrevoApiTransport extends AbstractTransport
+{
+    public function __construct(
+        private readonly string $apiKey
+    ) {
+        parent::__construct();
+    }
+
+    protected function doSend(SentMessage $message): void
+    {
+        $email = MessageConverter::toEmail($message->getOriginalMessage());
+
+        $config = Configuration::getDefaultConfiguration()->setApiKey('api-key', $this->apiKey);
+        $apiInstance = new TransactionalEmailsApi(new Client, $config);
+
+        $sendSmtpEmail = new SendSmtpEmail;
+
+        // Set sender
+        $from = $email->getFrom();
+        if (count($from) > 0) {
+            $fromAddress = $from[0];
+            $sendSmtpEmail->setSender([
+                'email' => $fromAddress->getAddress(),
+                'name' => $fromAddress->getName() ?? config('mail.from.name'),
+            ]);
+        }
+
+        // Set recipients
+        $to = array_map(function (Address $address) {
+            $recipient = ['email' => $address->getAddress()];
+            if ($address->getName()) {
+                $recipient['name'] = $address->getName();
+            }
+
+            return $recipient;
+        }, $email->getTo());
+        $sendSmtpEmail->setTo($to);
+
+        // Set CC
+        if (count($email->getCc()) > 0) {
+            $cc = array_map(function (Address $address) {
+                $recipient = ['email' => $address->getAddress()];
+                if ($address->getName()) {
+                    $recipient['name'] = $address->getName();
+                }
+
+                return $recipient;
+            }, $email->getCc());
+            $sendSmtpEmail->setCc($cc);
+        }
+
+        // Set BCC
+        if (count($email->getBcc()) > 0) {
+            $bcc = array_map(function (Address $address) {
+                $recipient = ['email' => $address->getAddress()];
+                if ($address->getName()) {
+                    $recipient['name'] = $address->getName();
+                }
+
+                return $recipient;
+            }, $email->getBcc());
+            $sendSmtpEmail->setBcc($bcc);
+        }
+
+        // Set subject
+        $sendSmtpEmail->setSubject($email->getSubject());
+
+        // Set reply-to
+        $replyTo = $email->getReplyTo();
+        if (count($replyTo) > 0) {
+            $replyToAddress = $replyTo[0];
+            $replyToData = ['email' => $replyToAddress->getAddress()];
+            if ($replyToAddress->getName()) {
+                $replyToData['name'] = $replyToAddress->getName();
+            }
+            $sendSmtpEmail->setReplyTo($replyToData);
+        }
+
+        // Set HTML and text content
+        if ($email->getHtmlBody()) {
+            $sendSmtpEmail->setHtmlContent($email->getHtmlBody());
+        }
+
+        if ($email->getTextBody()) {
+            $sendSmtpEmail->setTextContent($email->getTextBody());
+        }
+
+        // Send email via Brevo API
+        $apiInstance->sendTransacEmail($sendSmtpEmail);
+    }
+
+    public function __toString(): string
+    {
+        return 'brevo+api';
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Mail\Transport\BrevoApiTransport;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
@@ -36,6 +38,26 @@ class AppServiceProvider extends ServiceProvider
         view()->composer('components.layouts.header', function ($view) {
             $view->with('current_locale', app()->getLocale());
             $view->with('available_locales', config('app.available_locales'));
+        });
+
+        $this->configureMailTransports();
+    }
+
+    /**
+     * Register custom mail transports (Brevo HTTP API — same approach as Issue Forge).
+     */
+    protected function configureMailTransports(): void
+    {
+        Mail::extend('brevo', function (array $config) {
+            $apiKey = $config['api_key'] ?? config('services.brevo.api_key');
+
+            if (empty($apiKey)) {
+                throw new \RuntimeException(
+                    'Brevo API key is not configured. Please set BREVO_API_KEY in your .env file.'
+                );
+            }
+
+            return new BrevoApiTransport(apiKey: $apiKey);
         });
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^8.3",
         "doctrine/dbal": "^4.0",
+        "getbrevo/brevo-php": "^2.0",
         "guzzlehttp/guzzle": "^7.8",
         "laravel/framework": "^13.0",
         "laravel/passport": "^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1202b0b39fce8b96b65f6498cd117af0",
+    "content-hash": "059025554711a97680ce921d08d89c83",
     "packages": [
         {
             "name": "brick/math",
@@ -863,6 +863,69 @@
                 }
             ],
             "time": "2025-12-03T09:33:47+00:00"
+        },
+        {
+            "name": "getbrevo/brevo-php",
+            "version": "v2.0.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getbrevo/brevo-php.git",
+                "reference": "1abb1b75e06aa2ca3a6893d8e8d1968a8a76dc3f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getbrevo/brevo-php/zipball/1abb1b75e06aa2ca3a6893d8e8d1968a8a76dc3f",
+                "reference": "1abb1b75e06aa2ca3a6893d8e8d1968a8a76dc3f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "guzzlehttp/guzzle": "^7.4.0",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~1.12",
+                "phpunit/phpunit": "^4.8",
+                "squizlabs/php_codesniffer": "~2.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Brevo\\Client\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brevo Developers",
+                    "email": "contact@brevo.com",
+                    "homepage": "https://www.brevo.com/"
+                }
+            ],
+            "description": "Official Brevo provided RESTFul API V3 php library",
+            "homepage": "https://github.com/getbrevo/brevo-php",
+            "keywords": [
+                "api",
+                "brevo",
+                "php",
+                "sdk",
+                "swagger"
+            ],
+            "support": {
+                "issues": "https://github.com/getbrevo/brevo-php/issues",
+                "source": "https://github.com/getbrevo/brevo-php/tree/v2.0.14"
+            },
+            "time": "2025-11-06T10:13:45+00:00"
         },
         {
             "name": "graham-campbell/result-type",

--- a/config/mail.php
+++ b/config/mail.php
@@ -46,18 +46,12 @@ return [
         ],
 
         /*
-        | Same as `smtp` but defaults host to Brevo when MAIL_HOST is unset.
-        | Use MAIL_MAILER=brevo with MAIL_USERNAME / MAIL_PASSWORD (SMTP key) from Brevo.
+        | Brevo transactional API (HTTPS), same pattern as Issue Forge.
+        | Set MAIL_MAILER=brevo and BREVO_API_KEY (not SMTP). Registered in AppServiceProvider.
         */
         'brevo' => [
-            'transport' => 'smtp',
-            'host' => env('MAIL_HOST', 'smtp-relay.brevo.com'),
-            'port' => env('MAIL_PORT', 587),
-            'encryption' => env('MAIL_ENCRYPTION', 'tls'),
-            'username' => env('MAIL_USERNAME'),
-            'password' => env('MAIL_PASSWORD'),
-            'timeout' => null,
-            'auth_mode' => null,
+            'transport' => 'brevo',
+            'api_key' => env('BREVO_API_KEY'),
         ],
 
         'ses' => [

--- a/config/services.php
+++ b/config/services.php
@@ -30,4 +30,8 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'brevo' => [
+        'api_key' => env('BREVO_API_KEY'),
+    ],
+
 ];

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ High-level product and engineering priorities. Update this file in the same PR w
 | -------- | ---------------------------------------------------------------------------- |
 | Core app | Laravel 13, Blade, Vite, Bootstrap 5, bilingual frontend strings               |
 | Privacy  | First-party cookie UI (bottom strip + preference modal); web analytics via **self-hosted Matomo** (`analytics.kadsuno.com`) only after opt-in, configurable (see `config/matomo.php`, CHANGELOG) |
-| Ops      | Optional **Sentry** error reporting (`sentry/sentry-laravel`, `SENTRY_LARAVEL_DSN`, `config/sentry.php`); transactional email via Laravel **SMTP** (`MAIL_*`), e.g. **Brevo** in production (see README) |
+| Ops      | Optional **Sentry** error reporting (`sentry/sentry-laravel`, `SENTRY_LARAVEL_DSN`, `config/sentry.php`); transactional email via Laravel mailer — **SMTP** (`MAIL_*`) or **Brevo API** (`MAIL_MAILER=brevo`, `BREVO_API_KEY`, same pattern as Issue Forge; see README) |
 
 
 *Add rows or subsections here as major capabilities ship.*

--- a/docs/tickets/2026-04-08-brevo-api-transport-issue-forge-parity.md
+++ b/docs/tickets/2026-04-08-brevo-api-transport-issue-forge-parity.md
@@ -1,0 +1,22 @@
+## Title
+Brevo mailer: HTTP API transport (Issue Forge parity)
+
+## Summary
+Replace the previous SMTP-based `mail.mailers.brevo` entry with the same **Brevo transactional API** approach as Issue Forge (`BrevoApiTransport`, `Mail::extend`, `getbrevo/brevo-php`) so production works when outbound SMTP ports are blocked.
+
+## Background / Context
+- Issue Forge uses `MAIL_MAILER=brevo` + `BREVO_API_KEY` over HTTPS.
+- Smash Up Randomizer had defined `brevo` as SMTP relay; hosts often block port 587.
+
+## Requirements
+- [ ] `getbrevo/brevo-php` required; `App\Mail\Transport\BrevoApiTransport` + `Mail::extend('brevo')` in `AppServiceProvider`.
+- [ ] `config/mail.php` `brevo` uses `transport` => `brevo` and `api_key` from env.
+- [ ] `config/services.brevo.api_key`; `.env.example` documents `BREVO_API_KEY`.
+- [ ] README / CHANGELOG updated.
+
+## Testing
+- PHPUnit: `MailConfigTest` asserts `brevo` mailer config.
+- Manual: `MAIL_MAILER=brevo`, valid `BREVO_API_KEY`, contact form or `php artisan email:test`.
+
+## Impact / Risks
+- Deployments that used **`MAIL_MAILER=brevo` with SMTP credentials** must switch to **`BREVO_API_KEY`** (API key, not SMTP password).

--- a/tests/Unit/MailConfigTest.php
+++ b/tests/Unit/MailConfigTest.php
@@ -8,11 +8,11 @@ use Tests\TestCase;
 
 class MailConfigTest extends TestCase
 {
-    public function test_brevo_mailer_is_defined_as_smtp(): void
+    public function test_brevo_mailer_uses_api_transport(): void
     {
         $brevo = config('mail.mailers.brevo');
         $this->assertIsArray($brevo);
-        $this->assertSame('smtp', $brevo['transport']);
-        $this->assertArrayHasKey('host', $brevo);
+        $this->assertSame('brevo', $brevo['transport']);
+        $this->assertArrayHasKey('api_key', $brevo);
     }
 }


### PR DESCRIPTION
## Summary
`MAIL_MAILER=brevo` now uses the **Brevo transactional HTTP API** (`getbrevo/brevo-php`, `BrevoApiTransport`, `Mail::extend`), matching [Issue Forge](https://github.com/Kadsuno/issue-forge). Requires `BREVO_API_KEY` — avoids blocked outbound SMTP (587).

## Breaking note
Previous `brevo` mailer was SMTP. Production must set **`BREVO_API_KEY`** (API key from Brevo dashboard), not only SMTP `MAIL_PASSWORD`.

## Roadmap
Updated.

## Tests
`ddev exec php artisan test` — all pass.

Made with [Cursor](https://cursor.com)