### PR TITLE
feat: Blade sur-* layout components and scroll-reveal motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
+- **Frontend layout:** Blade views use shared `x-sur.*` components (container, section, hero, panel, page heading, scroll reveal) with `@alpinejs/intersect` for in-view motion; main landmark skip link; footer column entrance animation; shuffle wizard styles consolidated in `app.css`. Primary CTAs no longer use infinite pulse animations.
 - Matomo: frontend tracker now uses the self-hosted instance at `analytics.kadsuno.com` (replaces Matomo Cloud). Toggle with `MATOMO_ENABLED`; tracker URL and site id via `MATOMO_TRACKER_URL` and `MATOMO_SITE_ID` (`config/matomo.php`).
 - **Brevo (`MAIL_MAILER=brevo`):** uses the **Brevo HTTP API** (`getbrevo/brevo-php`, `App\Mail\Transport\BrevoApiTransport`, `Mail::extend` in `AppServiceProvider`) — same approach as [Issue Forge](https://github.com/Kadsuno/issue-forge). Set **`BREVO_API_KEY`** (not SMTP). For classic SMTP to any provider, keep **`MAIL_MAILER=smtp`** and `MAIL_*`.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@ High-level product and engineering priorities. Update this file in the same PR w
 
 | Area     | Notes                                                                        |
 | -------- | ---------------------------------------------------------------------------- |
-| Core app | Laravel 13, Blade, Vite, **Tailwind CSS 4** (dark-first UI), Alpine.js, bilingual frontend strings |
+| Core app | Laravel 13, Blade, Vite, **Tailwind CSS 4** (dark-first UI), Alpine.js (`sur-*` layout components, scroll-reveal), bilingual frontend strings |
 | Privacy  | First-party cookie UI (bottom strip + preference modal); web analytics via **self-hosted Matomo** (`analytics.kadsuno.com`) only after opt-in, configurable (see `config/matomo.php`, CHANGELOG) |
 | Ops      | Optional **Sentry** error reporting (`sentry/sentry-laravel`, `SENTRY_LARAVEL_DSN`, `config/sentry.php`); transactional email via Laravel mailer — **SMTP** (`MAIL_*`) or **Brevo API** (`MAIL_MAILER=brevo`, `BREVO_API_KEY`, same pattern as Issue Forge; see README) |
 

--- a/docs/tickets/2026-04-07-blade-structure-modernization.md
+++ b/docs/tickets/2026-04-07-blade-structure-modernization.md
@@ -1,0 +1,30 @@
+## Title
+Modernize Blade layout structure, reusable UI components, and motion
+
+## Summary
+Introduce consistent page structure (`sur-*` layout components), semantic `<main>` with skip link, footer stagger, and accessible motion (scroll-reveal via `@alpinejs/intersect`, staggered entrances; `prefers-reduced-motion` respected via existing global rules). Refactor public and backend guest views to use shared primitives and reduce reliance on animate.css for primary layout.
+
+## Background / Context
+- **Current state:** Pages mixed ad hoc wrappers (`max-w-7xl`, heroes), many `animate__*` classes, and inline page `<style>` blocks (e.g. shuffle wizard, faction list).
+- **Goal:** One predictable structure aligned with the indigo/zinc Tailwind design system, with subtle motion and less duplication.
+
+## Requirements
+- [x] Shared Blade components: **container**, **section**, **hero**, **panel** (glass), **reveal** (scroll-in), **page-heading**.
+- [x] **Main layout:** `id="main-content"`, flex column shell with `sur-main`, skip link to main content (EN/DE string).
+- [x] **Motion:** `x-intersect.once` + `.sur-reveal` / `.sur-reveal--in`; footer columns use CSS stagger; no infinite pulse on primary CTAs (replaced with hover/active scale).
+- [x] Refactor public pages: home, contact, about, imprint, privacy, faction list, shuffle results, login; backend dashboard and decks manager.
+- [x] **Alpine:** `@alpinejs/intersect` registered; `alpinejs` bumped to 3.15.x for compatibility.
+- [x] Production `npm run build` and PHPUnit green.
+
+## Technical notes
+- **Files:** `resources/views/components/sur/*`, `resources/views/components/layouts/{main,header,footer}.blade.php`, listed feature views, `resources/js/app.js`, `resources/css/app.css`, `lang/*/frontend.php`, `resources/lang/en/frontend.php`.
+- **Faction detail** (`decks/detail.blade.php`): kept existing scroll-snap + IntersectionObserver (separate motion model); not wrapped in `x-sur.reveal` to avoid double animation.
+- **Shuffle wizard:** Step classes renamed to `shuffle-step-content`, `shuffle-step-label`, `shuffle-progress-bar`; styles moved to `app.css`.
+
+## Testing
+- **PHPUnit:** `php artisan test` — all passing.
+- **Manual:** Home hero + modal steps, contact form, legal pages, faction list, shuffle results, login, backend dashboard and decks manager; tab to skip link; EN/DE if switching locale.
+
+## Impact / Risks
+- **Low:** Visual timing changes; animate.css still imported for any remaining utilities.
+- **Rollback:** Revert branch; restore previous Blade files from git.

--- a/lang/de/frontend.php
+++ b/lang/de/frontend.php
@@ -1,5 +1,6 @@
 <?php
 return [
+    'skip_to_content' => 'Zum Hauptinhalt springen',
     'start_header' => 'Willkommen zum Smash Up Randomizer',
     'start_teaser' => 'Mithilfe des Smash Up Randomizers können Fraktionen des Kartenspiels Smash Up gemischt und Spielern zugewiesen werden.',
     'number_players' => 'Anzahl der Spieler',

--- a/lang/en/frontend.php
+++ b/lang/en/frontend.php
@@ -1,5 +1,6 @@
 <?php
 return [
+    'skip_to_content' => 'Skip to main content',
     'start_header' => 'Welcome to Smash Up Randomizer',
     'start_teaser' => 'With the help of the Smash Up Randomizer, factions of the card game Smash Up can be shuffled and assigned to players.',
     'number_players' => 'Number of Players',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,14 @@
     "packages": {
         "": {
             "dependencies": {
+                "@alpinejs/intersect": "^3.15.11",
                 "@fortawesome/fontawesome-free": "^6.6.0",
                 "animate.css": "^4.1.1",
                 "jquery": "^3.7.1"
             },
             "devDependencies": {
                 "@tailwindcss/vite": "^4.1.0",
-                "alpinejs": "^3.4.2",
+                "alpinejs": "^3.15.11",
                 "autoprefixer": "^10.4.2",
                 "axios": "^0.21",
                 "laravel-vite-plugin": "^1.0.1",
@@ -23,6 +24,12 @@
             "engines": {
                 "node": ">=20.0.0"
             }
+        },
+        "node_modules/@alpinejs/intersect": {
+            "version": "3.15.11",
+            "resolved": "https://registry.npmjs.org/@alpinejs/intersect/-/intersect-3.15.11.tgz",
+            "integrity": "sha512-oGbp6vvn19vN8xoph32Wpo6DrGLXcMR/hLr8hh+gGhgrDpseDOG72h+lsjUivZYI58Uzs1oAxl7XPiQdRyRbtw==",
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.21.5",
@@ -1443,9 +1450,9 @@
             }
         },
         "node_modules/alpinejs": {
-            "version": "3.15.2",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.2.tgz",
-            "integrity": "sha512-2kYF2aG+DTFkE6p0rHG5XmN4VEb6sO9b02aOdU4+i8QN6rL0DbRZQiypDE1gBcGO65yDcqMz5KKYUYgMUxgNkw==",
+            "version": "3.15.11",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.11.tgz",
+            "integrity": "sha512-m26gkTg/MId8O+F4jHKK3vB3SjbFxxk/JHP+qzmw1H6aQrZuPAg4CUoAefnASzzp/eNroBjrRQe7950bNeaBJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.1.0",
-        "alpinejs": "^3.4.2",
+        "alpinejs": "^3.15.11",
         "autoprefixer": "^10.4.2",
         "axios": "^0.21",
         "laravel-vite-plugin": "^1.0.1",
@@ -19,6 +19,7 @@
         "node": ">=20.0.0"
     },
     "dependencies": {
+        "@alpinejs/intersect": "^3.15.11",
         "@fortawesome/fontawesome-free": "^6.6.0",
         "animate.css": "^4.1.1",
         "jquery": "^3.7.1"

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -197,4 +197,138 @@
     .sur-progress-fill {
         @apply h-full rounded-full bg-linear-to-r from-indigo-600 via-indigo-500 to-violet-500 transition-all duration-300 ease-out;
     }
+
+    .sur-main {
+        @apply flex min-h-0 w-full flex-1 flex-col;
+    }
+
+    .sur-skip-link {
+        position: absolute;
+        left: -9999px;
+        top: 0;
+        z-index: 100;
+        border-radius: 0.5rem;
+        background-color: #18181b;
+        padding: 0.5rem 1rem;
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: #fafafa;
+        text-decoration: none;
+        box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.45);
+    }
+
+    .sur-skip-link:focus {
+        left: max(1rem, env(safe-area-inset-left));
+        top: max(1rem, env(safe-area-inset-top));
+        outline: 2px solid rgba(129, 140, 248, 0.65);
+        outline-offset: 2px;
+    }
+
+    .sur-reveal {
+        opacity: 0;
+        transform: translateY(1.25rem);
+        transition:
+            opacity 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+            transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+        transition-delay: var(--sur-reveal-delay, 0ms);
+        will-change: opacity, transform;
+    }
+
+    .sur-reveal--in {
+        opacity: 1;
+        transform: translateY(0);
+        will-change: auto;
+    }
+
+    .bg-options {
+        background-repeat: no-repeat;
+        background-position: center;
+    }
+
+    .hero-height {
+        background-size: cover;
+        background-position: center;
+    }
+
+    .sur-footer-col {
+        animation: sur-footer-in 0.55s cubic-bezier(0.22, 1, 0.36, 1) backwards;
+    }
+
+    .sur-footer-col:nth-child(1) {
+        animation-delay: 0ms;
+    }
+
+    .sur-footer-col:nth-child(2) {
+        animation-delay: 0.08s;
+    }
+
+    .sur-footer-col:nth-child(3) {
+        animation-delay: 0.16s;
+    }
+}
+
+@keyframes sur-footer-in {
+    from {
+        opacity: 0;
+        transform: translateY(0.75rem);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Shuffle wizard (home modal) */
+.faction-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 0.5rem;
+}
+
+@media (min-width: 640px) {
+    .faction-grid {
+        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+        gap: 0.625rem;
+    }
+}
+
+.faction-item {
+    text-align: center;
+}
+
+.shuffle-progress-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #eef2ff;
+}
+
+.shuffle-step-label {
+    flex: 1;
+    text-align: center;
+    color: #71717a;
+}
+
+.shuffle-step-label.active {
+    color: #a5b4fc;
+    font-weight: 600;
+}
+
+.shuffle-step-content {
+    transition:
+        opacity 0.3s ease,
+        transform 0.3s ease;
+}
+
+.shuffle-step-content.slide-out {
+    opacity: 0;
+    transform: translateX(-100%);
+}
+
+.shuffle-step-content.slide-in {
+    opacity: 1;
+    transform: translateX(0);
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,5 +1,8 @@
 import Alpine from 'alpinejs';
+import intersect from '@alpinejs/intersect';
 import './cookie-banner';
+
+Alpine.plugin(intersect);
 
 window.Alpine = Alpine;
 

--- a/resources/lang/en/frontend.php
+++ b/resources/lang/en/frontend.php
@@ -1,5 +1,6 @@
 <?php
 return [
+    'skip_to_content' => 'Skip to main content',
     'start_header' => 'Welcome to Smash Up Randomizer',
     'start_teaser' => 'With the help of the Smash Up Randomizer, factions of the card game Smash Up can be shuffled and assigned to players.',
     'number_players' => 'Number of Players',

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,10 +1,10 @@
 <x-layouts.main>
-    <section class="mx-auto mt-8 max-w-6xl px-4 py-8 sm:mt-12 sm:px-6">
+    <x-sur.section :padded="true">
         <div class="flex flex-col gap-10 lg:flex-row lg:items-start lg:justify-center">
-            <div class="flex justify-center lg:w-2/5">
+            <x-sur.reveal class="flex justify-center lg:w-2/5">
                 <img src="{{ asset('images/login.svg') }}" class="max-h-72 w-full max-w-md object-contain" alt="" width="400" height="300">
-            </div>
-            <div class="mx-auto w-full max-w-md flex-1">
+            </x-sur.reveal>
+            <x-sur.reveal :delay="80" class="mx-auto w-full max-w-md flex-1">
                 <x-auth-session-status class="mb-4" :status="session('status')" />
                 <x-auth-validation-errors class="mb-4" :errors="$errors" />
 
@@ -39,7 +39,7 @@
                         </div>
                     </form>
                 </div>
-            </div>
+            </x-sur.reveal>
         </div>
-    </section>
+    </x-sur.section>
 </x-layouts.main>

--- a/resources/views/backend/dashboard.blade.php
+++ b/resources/views/backend/dashboard.blade.php
@@ -1,32 +1,42 @@
 <x-layouts.backend.backendMain>
-    <div class="animate__animated animate__fadeIn text-zinc-100">
-        <h1 class="mb-8 text-center text-3xl font-bold text-white sm:text-4xl">
-            {{ __('backend.dashboard_header') }}
-        </h1>
-        <div class="mb-8 max-w-3xl">
-            <p class="mb-4 text-lg leading-relaxed text-zinc-300">
-                {{ __('backend.dashboard_body') }}
-            </p>
-            <p class="text-zinc-400">
-                {{ __('backend.dashboard_welcome') }}
-            </p>
-        </div>
+    <div class="text-zinc-100">
+        <x-sur.reveal>
+            <h1 class="mb-8 text-center text-3xl font-bold text-white sm:text-4xl">
+                {{ __('backend.dashboard_header') }}
+            </h1>
+        </x-sur.reveal>
+        <x-sur.reveal :delay="50">
+            <div class="mb-8 max-w-3xl">
+                <p class="mb-4 text-lg leading-relaxed text-zinc-300">
+                    {{ __('backend.dashboard_body') }}
+                </p>
+                <p class="text-zinc-400">
+                    {{ __('backend.dashboard_welcome') }}
+                </p>
+            </div>
+        </x-sur.reveal>
         <div class="grid gap-6 md:grid-cols-3">
-            <div class="sur-card border-white/10">
-                <h2 class="mb-2 text-lg font-semibold text-indigo-300">{{ __('backend.dashboard_quick_stats') }}</h2>
-                <p class="mb-4 text-sm text-zinc-400">{{ __('backend.dashboard_stats_description') }}</p>
-                <a href="#" class="sur-btn-ghost min-h-10 text-sm">{{ __('backend.view_stats') }}</a>
-            </div>
-            <div class="sur-card border-white/10">
-                <h2 class="mb-2 text-lg font-semibold text-indigo-300">{{ __('backend.dashboard_recent_activity') }}</h2>
-                <p class="mb-4 text-sm text-zinc-400">{{ __('backend.dashboard_activity_description') }}</p>
-                <a href="#" class="sur-btn-ghost min-h-10 text-sm">{{ __('backend.view_activity') }}</a>
-            </div>
-            <div class="sur-card border-white/10">
-                <h2 class="mb-2 text-lg font-semibold text-indigo-300">{{ __('backend.dashboard_quick_actions') }}</h2>
-                <p class="mb-4 text-sm text-zinc-400">{{ __('backend.dashboard_actions_description') }}</p>
-                <a href="#" class="sur-btn-ghost min-h-10 text-sm">{{ __('backend.perform_action') }}</a>
-            </div>
+            <x-sur.reveal :delay="80">
+                <div class="sur-card border-white/10">
+                    <h2 class="mb-2 text-lg font-semibold text-indigo-300">{{ __('backend.dashboard_quick_stats') }}</h2>
+                    <p class="mb-4 text-sm text-zinc-400">{{ __('backend.dashboard_stats_description') }}</p>
+                    <a href="#" class="sur-btn-ghost min-h-10 text-sm">{{ __('backend.view_stats') }}</a>
+                </div>
+            </x-sur.reveal>
+            <x-sur.reveal :delay="120">
+                <div class="sur-card border-white/10">
+                    <h2 class="mb-2 text-lg font-semibold text-indigo-300">{{ __('backend.dashboard_recent_activity') }}</h2>
+                    <p class="mb-4 text-sm text-zinc-400">{{ __('backend.dashboard_activity_description') }}</p>
+                    <a href="#" class="sur-btn-ghost min-h-10 text-sm">{{ __('backend.view_activity') }}</a>
+                </div>
+            </x-sur.reveal>
+            <x-sur.reveal :delay="160">
+                <div class="sur-card border-white/10">
+                    <h2 class="mb-2 text-lg font-semibold text-indigo-300">{{ __('backend.dashboard_quick_actions') }}</h2>
+                    <p class="mb-4 text-sm text-zinc-400">{{ __('backend.dashboard_actions_description') }}</p>
+                    <a href="#" class="sur-btn-ghost min-h-10 text-sm">{{ __('backend.perform_action') }}</a>
+                </div>
+            </x-sur.reveal>
         </div>
     </div>
 </x-layouts.backend.backendMain>

--- a/resources/views/backend/decks-manager.blade.php
+++ b/resources/views/backend/decks-manager.blade.php
@@ -1,54 +1,54 @@
 <x-layouts.backend.backendMain>
-    <div class="animate__animated animate__fadeIn">
-        <h1 class="mb-8 text-center text-3xl font-bold text-white animate__animated animate__slideInDown">{{ __('backend.nav_faction_manager') }}</h1>
+    <div>
+        <x-sur.reveal>
+            <h1 class="mb-8 text-center text-3xl font-bold text-white">{{ __('backend.nav_faction_manager') }}</h1>
+        </x-sur.reveal>
 
-        <div class="mb-8 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-            <a href="{{ route('add-deck') }}" class="sur-btn-primary inline-flex min-h-12 w-fit animate__animated animate__pulse items-center gap-2">
-                <i class="fas fa-plus" aria-hidden="true"></i> {{ __('backend.add_decks') }}
-            </a>
-            <form action="{{ route('add-deck-csv') }}" method="POST" enctype="multipart/form-data" class="flex w-full max-w-xl flex-col gap-3 sm:flex-row sm:items-center">
-                @csrf
-                <label class="sr-only" for="csv-import">{{ __('backend.headline_csv') }}</label>
-                <input type="file" id="csv-import" name="csv" accept=".csv" required
-                    class="block w-full cursor-pointer rounded-xl border border-white/10 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-200 file:mr-3 file:rounded-lg file:border-0 file:bg-indigo-600 file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-zinc-950 hover:file:bg-indigo-500">
-                <button class="sur-btn-secondary min-h-11 shrink-0" type="submit">{{ __('backend.upload') }}</button>
-            </form>
-        </div>
-
-        <div class="sur-card overflow-hidden border-white/10 p-0 animate__animated animate__fadeInUp">
-            <div class="overflow-x-auto">
-                <table class="w-full min-w-[28rem] text-left text-sm text-zinc-300">
-                    <thead class="border-b border-white/10 bg-zinc-900/80 text-xs uppercase tracking-wide text-zinc-500">
-                        <tr>
-                            <th class="px-4 py-3 font-semibold">{{ __('backend.deck_name') }}</th>
-                            <th class="px-4 py-3 text-end font-semibold">{{ __('backend.table_actions') }}</th>
-                        </tr>
-                    </thead>
-                    <tbody class="divide-y divide-white/5">
-                        @foreach ($decks as $deck)
-                            <tr class="transition hover:bg-white/[0.03] animate__animated animate__fadeIn" style="animation-delay: {{ $loop->index * 0.1 }}s">
-                                <td class="px-4 py-3 font-medium text-zinc-100">{{ $deck->name }}</td>
-                                <td class="px-4 py-3">
-                                    <div class="flex justify-end gap-2">
-                                        <a href="{{ route('edit-deck', $deck->name) }}" class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/15 text-zinc-200 transition hover:border-indigo-500/40 hover:text-indigo-300" title="{{ __('backend.edit_deck') }}">
-                                            <i class="fas fa-edit" aria-hidden="true"></i>
-                                        </a>
-                                        <a href="{{ route('delete-decks', $deck->name) }}" class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-red-500/30 text-red-300 transition hover:bg-red-500/10" title="{{ __('backend.delete_decks') }}" onclick="return confirm('{{ __('backend.confirm_delete') }}')">
-                                            <i class="fas fa-trash-alt" aria-hidden="true"></i>
-                                        </a>
-                                    </div>
-                                </td>
-                            </tr>
-                        @endforeach
-                    </tbody>
-                </table>
+        <x-sur.reveal :delay="60">
+            <div class="mb-8 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                <a href="{{ route('add-deck') }}" class="sur-btn-primary inline-flex min-h-12 w-fit items-center gap-2 transition-transform hover:scale-[1.02] active:scale-[0.98]">
+                    <i class="fas fa-plus" aria-hidden="true"></i> {{ __('backend.add_decks') }}
+                </a>
+                <form action="{{ route('add-deck-csv') }}" method="POST" enctype="multipart/form-data" class="flex w-full max-w-xl flex-col gap-3 sm:flex-row sm:items-center">
+                    @csrf
+                    <label class="sr-only" for="csv-import">{{ __('backend.headline_csv') }}</label>
+                    <input type="file" id="csv-import" name="csv" accept=".csv" required
+                        class="block w-full cursor-pointer rounded-xl border border-white/10 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-200 file:mr-3 file:rounded-lg file:border-0 file:bg-indigo-600 file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-zinc-950 hover:file:bg-indigo-500">
+                    <button class="sur-btn-secondary min-h-11 shrink-0" type="submit">{{ __('backend.upload') }}</button>
+                </form>
             </div>
-        </div>
-    </div>
+        </x-sur.reveal>
 
-    <style>
-        .animate__animated {
-            animation-duration: 0.5s;
-        }
-    </style>
+        <x-sur.reveal :delay="100">
+            <div class="sur-card overflow-hidden border-white/10 p-0">
+                <div class="overflow-x-auto">
+                    <table class="w-full min-w-[28rem] text-left text-sm text-zinc-300">
+                        <thead class="border-b border-white/10 bg-zinc-900/80 text-xs uppercase tracking-wide text-zinc-500">
+                            <tr>
+                                <th class="px-4 py-3 font-semibold">{{ __('backend.deck_name') }}</th>
+                                <th class="px-4 py-3 text-end font-semibold">{{ __('backend.table_actions') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                            @foreach ($decks as $deck)
+                                <tr class="transition hover:bg-white/[0.03]">
+                                    <td class="px-4 py-3 font-medium text-zinc-100">{{ $deck->name }}</td>
+                                    <td class="px-4 py-3">
+                                        <div class="flex justify-end gap-2">
+                                            <a href="{{ route('edit-deck', $deck->name) }}" class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/15 text-zinc-200 transition hover:border-indigo-500/40 hover:text-indigo-300" title="{{ __('backend.edit_deck') }}">
+                                                <i class="fas fa-edit" aria-hidden="true"></i>
+                                            </a>
+                                            <a href="{{ route('delete-decks', $deck->name) }}" class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-red-500/30 text-red-300 transition hover:bg-red-500/10" title="{{ __('backend.delete_decks') }}" onclick="return confirm('{{ __('backend.confirm_delete') }}')">
+                                                <i class="fas fa-trash-alt" aria-hidden="true"></i>
+                                            </a>
+                                        </div>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </x-sur.reveal>
+    </div>
 </x-layouts.backend.backendMain>

--- a/resources/views/components/layouts/backend/backendMain.blade.php
+++ b/resources/views/components/layouts/backend/backendMain.blade.php
@@ -69,14 +69,6 @@
                 });
             }
 
-            sidebarLinks.forEach(function (link) {
-                link.addEventListener('mouseenter', function () {
-                    this.classList.add('animate__animated', 'animate__pulse');
-                });
-                link.addEventListener('mouseleave', function () {
-                    this.classList.remove('animate__animated', 'animate__pulse');
-                });
-            });
         });
     </script>
     <style>

--- a/resources/views/components/layouts/footer.blade.php
+++ b/resources/views/components/layouts/footer.blade.php
@@ -1,11 +1,11 @@
-<footer class="border-t border-white/10 bg-black py-10 text-zinc-300">
-    <div class="mx-auto max-w-7xl px-4 sm:px-6">
+<footer class="mt-auto border-t border-white/10 bg-black py-10 text-zinc-300">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="grid gap-10 md:grid-cols-3">
-            <div>
+            <div class="sur-footer-col">
                 <h2 class="mb-3 text-xs font-semibold uppercase tracking-widest text-zinc-500">Smash Up Randomizer</h2>
                 <p class="text-sm leading-relaxed text-zinc-400">Shuffle and assign factions for your next Smash Up game with ease.</p>
             </div>
-            <div>
+            <div class="sur-footer-col">
                 <h2 class="mb-3 text-xs font-semibold uppercase tracking-widest text-zinc-500">{{ __('frontend.footer_quick_links') }}</h2>
                 <ul class="space-y-2 text-sm">
                     <li>
@@ -16,7 +16,7 @@
                     </li>
                 </ul>
             </div>
-            <div>
+            <div class="sur-footer-col">
                 <h2 class="mb-3 text-xs font-semibold uppercase tracking-widest text-zinc-500">{{ __('frontend.footer_connect') }}</h2>
                 <div class="flex gap-4">
                     <a href="https://www.facebook.com/SmashUpRandomizer/" class="flex h-11 w-11 items-center justify-center rounded-xl border border-white/10 text-zinc-200 transition hover:border-indigo-500/40 hover:text-indigo-400" aria-label="Facebook" rel="noopener noreferrer">

--- a/resources/views/components/layouts/header.blade.php
+++ b/resources/views/components/layouts/header.blade.php
@@ -29,7 +29,8 @@
 
 </head>
 
-<body class="min-h-screen bg-zinc-950 text-zinc-100 antialiased">
+<body class="flex min-h-screen flex-col bg-zinc-950 text-zinc-100 antialiased">
+    <a href="#main-content" class="sur-skip-link">{{ __('frontend.skip_to_content') }}</a>
     <nav
         x-data="{ open: false }"
         @keydown.window.escape="open = false"

--- a/resources/views/components/layouts/main.blade.php
+++ b/resources/views/components/layouts/main.blade.php
@@ -1,5 +1,5 @@
 <x-layouts.header />
-    <main class="pt-16">
+    <main id="main-content" class="sur-main flex min-h-0 flex-1 flex-col pt-16 outline-none" tabindex="-1">
         {{ $slot }}
     </main>
 <x-layouts.footer />

--- a/resources/views/components/sur/container.blade.php
+++ b/resources/views/components/sur/container.blade.php
@@ -1,0 +1,9 @@
+@props(['narrow' => false])
+
+@php
+    $max = $narrow ? 'max-w-3xl' : 'max-w-7xl';
+@endphp
+
+<div {{ $attributes->merge(['class' => 'mx-auto w-full px-4 sm:px-6 lg:px-8 ' . $max]) }}>
+    {{ $slot }}
+</div>

--- a/resources/views/components/sur/hero.blade.php
+++ b/resources/views/components/sur/hero.blade.php
@@ -1,0 +1,22 @@
+@props([
+    'image' => null,
+    'minClass' => 'min-h-[70vh] sm:min-h-[80vh]',
+    'bgId' => null,
+])
+
+<section {{ $attributes->merge(['class' => 'relative w-full overflow-hidden']) }}>
+    @if ($image)
+        <div
+            @if ($bgId) id="{{ $bgId }}" @endif
+            class="bg-options hero-height {{ $minClass }}"
+            style="background-image: url('{{ $image }}');"
+        >
+            <div class="pointer-events-none absolute inset-0 bg-linear-to-b from-black/45 via-black/10 to-zinc-950/85" aria-hidden="true"></div>
+            <div class="relative z-10 mx-auto flex min-h-[inherit] w-full max-w-7xl flex-col justify-center px-4 sm:px-6 lg:px-8">
+                {{ $slot }}
+            </div>
+        </div>
+    @else
+        {{ $slot }}
+    @endif
+</section>

--- a/resources/views/components/sur/page-heading.blade.php
+++ b/resources/views/components/sur/page-heading.blade.php
@@ -1,0 +1,10 @@
+@props(['subtitle' => null])
+
+<header {{ $attributes->merge(['class' => 'mb-10 text-center md:mb-12']) }}>
+    <h1 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        {{ $slot }}
+    </h1>
+    @if ($subtitle)
+        <p class="mx-auto mt-3 max-w-2xl text-sm text-zinc-400 sm:text-base">{{ $subtitle }}</p>
+    @endif
+</header>

--- a/resources/views/components/sur/panel.blade.php
+++ b/resources/views/components/sur/panel.blade.php
@@ -1,0 +1,3 @@
+<div {{ $attributes->merge(['class' => 'max-w-xl rounded-2xl border border-white/10 bg-black/70 p-6 shadow-2xl backdrop-blur-md sm:p-8']) }}>
+    {{ $slot }}
+</div>

--- a/resources/views/components/sur/reveal.blade.php
+++ b/resources/views/components/sur/reveal.blade.php
@@ -1,0 +1,13 @@
+@props(['delay' => 0])
+
+<div
+    x-data="{ inView: false }"
+    x-intersect.once="inView = true"
+    x-bind:class="inView ? 'sur-reveal sur-reveal--in' : 'sur-reveal'"
+    @if ((int) $delay > 0)
+        style="--sur-reveal-delay: {{ (int) $delay }}ms"
+    @endif
+    {{ $attributes }}
+>
+    {{ $slot }}
+</div>

--- a/resources/views/components/sur/section.blade.php
+++ b/resources/views/components/sur/section.blade.php
@@ -1,0 +1,11 @@
+@props(['padded' => true, 'narrow' => false])
+
+@php
+    $py = $padded ? 'py-12 md:py-16 lg:py-20' : '';
+@endphp
+
+<section {{ $attributes->merge(['class' => trim($py)]) }}>
+    <x-sur.container :narrow="$narrow">
+        {{ $slot }}
+    </x-sur.container>
+</section>

--- a/resources/views/contact/contactForm.blade.php
+++ b/resources/views/contact/contactForm.blade.php
@@ -1,99 +1,93 @@
 <x-layouts.main>
-    <div id="hero-header" class="animate__animated animate__fadeIn">
-        <div class="relative w-full overflow-hidden">
-            <div class="bg-options min-h-[50vh] sm:min-h-[60vh]" id="hero-js" style="background-image: url('{{ asset('images/contact_2.png') }}'); background-attachment: scroll; background-position: center; background-size: cover;">
-                <div class="mx-auto max-w-7xl px-4 sm:px-6">
-                    <div class="max-w-xl py-10 sm:py-16">
-                        <div class="rounded-2xl border border-white/10 bg-black/70 px-6 py-8 shadow-2xl backdrop-blur-md animate__animated animate__slideInLeft sm:px-8">
-                            <h1 class="mb-4 text-3xl font-extrabold text-white sm:text-4xl">
-                                Contact Us
-                            </h1>
-                            <p class="text-sm leading-relaxed text-zinc-200 sm:text-base">
-                                Do you have a question, want to find out more about Smash Up Randomizer or just want to say hello? Then you've come to the right place! We are always open to inquiries, feedback or exciting stories about our shared hobby. Simply fill out the contact form or send us an e-mail. We look forward to hearing from you. We'll get back to you faster than you can shuffle cards!
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </div>
+    <x-sur.hero
+        :image="asset('images/contact_2.png')"
+        bg-id="hero-js"
+        id="hero-header"
+        min-class="min-h-[50vh] sm:min-h-[60vh]"
+    >
+        <div class="max-w-xl py-10 sm:py-16">
+            <x-sur.reveal>
+                <x-sur.panel>
+                    <h1 class="mb-4 text-3xl font-extrabold text-white sm:text-4xl">
+                        Contact Us
+                    </h1>
+                    <p class="text-sm leading-relaxed text-zinc-200 sm:text-base">
+                        Do you have a question, want to find out more about Smash Up Randomizer or just want to say hello? Then you've come to the right place! We are always open to inquiries, feedback or exciting stories about our shared hobby. Simply fill out the contact form or send us an e-mail. We look forward to hearing from you. We'll get back to you faster than you can shuffle cards!
+                    </p>
+                </x-sur.panel>
+            </x-sur.reveal>
         </div>
-    </div>
-    <div class="mx-auto max-w-7xl px-4 py-10 sm:px-6">
-        <h2 class="mb-8 text-center text-2xl font-bold text-white animate__animated animate__fadeInDown">
-            Contact Form
-        </h2>
-    </div>
-    <div class="mx-auto mb-16 max-w-7xl px-4 sm:px-6">
+    </x-sur.hero>
+
+    <x-sur.section :padded="true">
+        <x-sur.reveal>
+            <h2 class="mb-8 text-center text-2xl font-bold text-white">
+                Contact Form
+            </h2>
+        </x-sur.reveal>
         <div class="mx-auto max-w-3xl">
             @if (Session::has('success'))
-            <div class="mb-6 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-center text-sm text-emerald-200 animate__animated animate__fadeIn">
+            <div class="mb-6 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-center text-sm text-emerald-200">
                 {{ Session::get('success') }}
             </div>
             @endif
             @if (Session::has('error'))
-            <div class="mb-6 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-center text-sm text-red-200 animate__animated animate__fadeIn">
+            <div class="mb-6 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-center text-sm text-red-200">
                 {{ Session::get('error') }}
             </div>
             @endif
-            <form method="POST" action="{{ route('contact.us.store') }}" id="contactUSForm" class="needs-validation sur-card border-white/10 p-6 animate__animated animate__fadeInUp sm:p-8" novalidate>
-                {{ csrf_field() }}
+            <x-sur.reveal :delay="60">
+                <form method="POST" action="{{ route('contact.us.store') }}" id="contactUSForm" class="needs-validation sur-card border-white/10 p-6 sm:p-8" novalidate>
+                    {{ csrf_field() }}
 
-                <div class="grid gap-4 sm:grid-cols-2">
-                    <div>
-                        <label for="name" class="mb-2 block text-sm font-medium text-zinc-300">Name: <span class="text-red-400">*</span></label>
-                        <input type="text" name="name" id="name" class="sur-input" placeholder="Your Name" value="{{ old('name') }}" required>
-                        @if ($errors->has('name'))
-                        <span class="mt-1 block text-sm text-red-400">{{ $errors->first('name') }}</span>
+                    <div class="grid gap-4 sm:grid-cols-2">
+                        <div>
+                            <label for="name" class="mb-2 block text-sm font-medium text-zinc-300">Name: <span class="text-red-400">*</span></label>
+                            <input type="text" name="name" id="name" class="sur-input" placeholder="Your Name" value="{{ old('name') }}" required>
+                            @if ($errors->has('name'))
+                            <span class="mt-1 block text-sm text-red-400">{{ $errors->first('name') }}</span>
+                            @endif
+                        </div>
+                        <div>
+                            <label for="email" class="mb-2 block text-sm font-medium text-zinc-300">Email: <span class="text-red-400">*</span></label>
+                            <input type="email" name="email" id="email" class="sur-input" placeholder="Your Email" value="{{ old('email') }}" required>
+                            @if ($errors->has('email'))
+                            <span class="mt-1 block text-sm text-red-400">{{ $errors->first('email') }}</span>
+                            @endif
+                        </div>
+                    </div>
+                    <div class="mt-4 grid gap-4 sm:grid-cols-2">
+                        <div>
+                            <label for="phone" class="mb-2 block text-sm font-medium text-zinc-300">Phone: <span class="text-red-400">*</span></label>
+                            <input type="tel" name="phone" id="phone" class="sur-input" placeholder="Your Phone" value="{{ old('phone') }}" required>
+                            @if ($errors->has('phone'))
+                            <span class="mt-1 block text-sm text-red-400">{{ $errors->first('phone') }}</span>
+                            @endif
+                        </div>
+                        <div>
+                            <label for="subject" class="mb-2 block text-sm font-medium text-zinc-300">Subject: <span class="text-red-400">*</span></label>
+                            <input type="text" name="subject" id="subject" class="sur-input" placeholder="Message Subject" value="{{ old('subject') }}" required>
+                            @if ($errors->has('subject'))
+                            <span class="mt-1 block text-sm text-red-400">{{ $errors->first('subject') }}</span>
+                            @endif
+                        </div>
+                    </div>
+                    <div class="mt-4">
+                        <label for="message" class="mb-2 block text-sm font-medium text-zinc-300">Message: <span class="text-red-400">*</span></label>
+                        <textarea name="message" id="message" rows="5" placeholder="What is on your mind?" class="sur-input min-h-[8rem]" required>{{ old('message') }}</textarea>
+                        @if ($errors->has('message'))
+                        <span class="mt-1 block text-sm text-red-400">{{ $errors->first('message') }}</span>
                         @endif
                     </div>
-                    <div>
-                        <label for="email" class="mb-2 block text-sm font-medium text-zinc-300">Email: <span class="text-red-400">*</span></label>
-                        <input type="email" name="email" id="email" class="sur-input" placeholder="Your Email" value="{{ old('email') }}" required>
-                        @if ($errors->has('email'))
-                        <span class="mt-1 block text-sm text-red-400">{{ $errors->first('email') }}</span>
-                        @endif
-                    </div>
-                </div>
-                <div class="mt-4 grid gap-4 sm:grid-cols-2">
-                    <div>
-                        <label for="phone" class="mb-2 block text-sm font-medium text-zinc-300">Phone: <span class="text-red-400">*</span></label>
-                        <input type="tel" name="phone" id="phone" class="sur-input" placeholder="Your Phone" value="{{ old('phone') }}" required>
-                        @if ($errors->has('phone'))
-                        <span class="mt-1 block text-sm text-red-400">{{ $errors->first('phone') }}</span>
-                        @endif
-                    </div>
-                    <div>
-                        <label for="subject" class="mb-2 block text-sm font-medium text-zinc-300">Subject: <span class="text-red-400">*</span></label>
-                        <input type="text" name="subject" id="subject" class="sur-input" placeholder="Message Subject" value="{{ old('subject') }}" required>
-                        @if ($errors->has('subject'))
-                        <span class="mt-1 block text-sm text-red-400">{{ $errors->first('subject') }}</span>
-                        @endif
-                    </div>
-                </div>
-                <div class="mt-4">
-                    <label for="message" class="mb-2 block text-sm font-medium text-zinc-300">Message: <span class="text-red-400">*</span></label>
-                    <textarea name="message" id="message" rows="5" placeholder="What is on your mind?" class="sur-input min-h-[8rem]" required>{{ old('message') }}</textarea>
-                    @if ($errors->has('message'))
-                    <span class="mt-1 block text-sm text-red-400">{{ $errors->first('message') }}</span>
-                    @endif
-                </div>
 
-                <input type="text" name="context" id="context" class="hidden" tabindex="-1" autocomplete="off">
-                <input type="hidden" name="start_time" value="{{ time() }}">
+                    <input type="text" name="context" id="context" class="hidden" tabindex="-1" autocomplete="off">
+                    <input type="hidden" name="start_time" value="{{ time() }}">
 
-                <div class="mt-8 text-center">
-                    <button type="submit" class="sur-btn-primary min-h-12 animate__animated animate__pulse animate__infinite">Submit</button>
-                </div>
-            </form>
+                    <div class="mt-8 text-center">
+                        <button type="submit" class="sur-btn-primary min-h-12 transition-transform hover:scale-[1.02] active:scale-[0.98]">Submit</button>
+                    </div>
+                </form>
+            </x-sur.reveal>
         </div>
-    </div>
+    </x-sur.section>
 </x-layouts.main>
-
-<style>
-    .bg-options {
-        background-repeat: no-repeat;
-        background-position: center;
-    }
-    .animate__animated {
-        animation-duration: 1s;
-    }
-</style>

--- a/resources/views/decks/list.blade.php
+++ b/resources/views/decks/list.blade.php
@@ -1,48 +1,37 @@
 <x-layouts.main>
-    <div class="mx-auto max-w-7xl px-4 pb-16 pt-24 sm:px-6">
+    <x-sur.section :padded="true">
         <div class="mb-6 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-center text-sm text-amber-100">
             <strong>Work in Progress</strong> — This page is currently under construction. Thank you for your patience.
         </div>
-        <h1 class="mb-8 text-center text-3xl font-bold text-white animate__animated animate__fadeInDown">Faction List</h1>
+        <x-sur.reveal>
+            <x-sur.page-heading class="mb-8">Faction List</x-sur.page-heading>
+        </x-sur.reveal>
         <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             @foreach($decks as $deck)
                 @if($deck->teaser)
-                <a href="{{ route('factionDetail', ['name' => $deck->name]) }}" class="group block rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60">
-                    <div class="sur-card-interactive h-full overflow-hidden p-0 animate__animated animate__fadeIn">
-                        @if($deck->image)
-                            <img src="{{ asset($deck->image) }}" class="h-48 w-full object-cover transition duration-300 group-hover:scale-[1.02]" alt="{{ $deck->name }}">
-                        @else
-                            <div class="flex h-48 items-center justify-center bg-linear-to-br from-zinc-800 to-zinc-900 text-zinc-500">
-                                <span>No Image Available</span>
-                            </div>
-                        @endif
-                        <div class="p-5">
-                            <h2 class="mb-2 text-lg font-bold text-white group-hover:text-indigo-300">{{ $deck->name }}</h2>
-                            @if($deck->teaser)
-                                <p class="line-clamp-4 text-sm leading-relaxed text-zinc-400">{!! $deck->teaser !!}</p>
+                <x-sur.reveal :delay="$loop->index * 55">
+                    <a href="{{ route('factionDetail', ['name' => $deck->name]) }}" class="group block rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/60">
+                        <div class="sur-card-interactive h-full overflow-hidden p-0">
+                            @if($deck->image)
+                                <img src="{{ asset($deck->image) }}" class="h-48 w-full object-cover transition duration-300 group-hover:scale-[1.02]" alt="{{ $deck->name }}">
                             @else
-                                <p class="text-sm italic text-zinc-500">No description available.</p>
+                                <div class="flex h-48 items-center justify-center bg-linear-to-br from-zinc-800 to-zinc-900 text-zinc-500">
+                                    <span>No Image Available</span>
+                                </div>
                             @endif
+                            <div class="p-5">
+                                <h2 class="mb-2 text-lg font-bold text-white group-hover:text-indigo-300">{{ $deck->name }}</h2>
+                                @if($deck->teaser)
+                                    <p class="line-clamp-4 text-sm leading-relaxed text-zinc-400">{!! $deck->teaser !!}</p>
+                                @else
+                                    <p class="text-sm italic text-zinc-500">No description available.</p>
+                                @endif
+                            </div>
                         </div>
-                    </div>
-                </a>
+                    </a>
+                </x-sur.reveal>
                 @endif
             @endforeach
         </div>
-    </div>
+    </x-sur.section>
 </x-layouts.main>
-
-<style>
-    .animate__animated {
-        animation-duration: 1s;
-    }
-</style>
-
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const cards = document.querySelectorAll('.sur-card-interactive');
-        cards.forEach((card, index) => {
-            card.style.animationDelay = `${index * 0.1}s`;
-        });
-    });
-</script>

--- a/resources/views/legal/about.blade.php
+++ b/resources/views/legal/about.blade.php
@@ -1,35 +1,43 @@
 <x-layouts.main>
+    <x-sur.section :narrow="true">
+        <x-sur.reveal>
+            <x-sur.page-heading>About Smash Up Randomizer</x-sur.page-heading>
+        </x-sur.reveal>
 
-<div class="mx-auto max-w-3xl px-4 py-16 pt-24 sm:px-6">
-    <h1 class="mb-10 text-center text-3xl font-bold text-white sm:text-4xl">About Smash Up Randomizer</h1>
+        <x-sur.reveal :delay="40">
+            <div class="sur-card mb-8 border-white/10">
+                <h2 class="mb-4 text-lg font-semibold text-indigo-300">Our Mission</h2>
+                <p class="leading-relaxed text-zinc-300">
+                    Smash Up Randomizer is dedicated to enhancing your Smash Up gaming experience. We aim to provide a quick, fair, and fun way to randomize faction assignments for your games.
+                </p>
+            </div>
+        </x-sur.reveal>
 
-    <div class="sur-card mb-8 border-white/10">
-        <h2 class="mb-4 text-lg font-semibold text-indigo-300">Our Mission</h2>
-        <p class="leading-relaxed text-zinc-300">
-            Smash Up Randomizer is dedicated to enhancing your Smash Up gaming experience. We aim to provide a quick, fair, and fun way to randomize faction assignments for your games.
-        </p>
-    </div>
+        <x-sur.reveal :delay="80">
+            <div class="sur-card mb-8 border-white/10">
+                <h2 class="mb-4 text-lg font-semibold text-indigo-300">How It Works</h2>
+                <p class="leading-relaxed text-zinc-300">
+                    Our randomizer uses a sophisticated algorithm to ensure fair and truly random faction assignments. Simply input the number of players and available factions, and let our tool do the rest!
+                </p>
+            </div>
+        </x-sur.reveal>
 
-    <div class="sur-card mb-8 border-white/10">
-        <h2 class="mb-4 text-lg font-semibold text-indigo-300">How It Works</h2>
-        <p class="leading-relaxed text-zinc-300">
-            Our randomizer uses a sophisticated algorithm to ensure fair and truly random faction assignments. Simply input the number of players and available factions, and let our tool do the rest!
-        </p>
-    </div>
+        <x-sur.reveal :delay="120">
+            <div class="sur-card mb-10 border-white/10">
+                <h2 class="mb-4 text-lg font-semibold text-indigo-300">Why Choose Us</h2>
+                <ul class="space-y-2 text-zinc-300">
+                    <li class="flex gap-2"><i class="fas fa-check-circle mt-0.5 text-emerald-400" aria-hidden="true"></i> Easy to use interface</li>
+                    <li class="flex gap-2"><i class="fas fa-check-circle mt-0.5 text-emerald-400" aria-hidden="true"></i> Truly random assignments</li>
+                    <li class="flex gap-2"><i class="fas fa-check-circle mt-0.5 text-emerald-400" aria-hidden="true"></i> Regularly updated faction list</li>
+                    <li class="flex gap-2"><i class="fas fa-check-circle mt-0.5 text-emerald-400" aria-hidden="true"></i> Free to use</li>
+                </ul>
+            </div>
+        </x-sur.reveal>
 
-    <div class="sur-card mb-10 border-white/10">
-        <h2 class="mb-4 text-lg font-semibold text-indigo-300">Why Choose Us</h2>
-        <ul class="space-y-2 text-zinc-300">
-            <li class="flex gap-2"><i class="fas fa-check-circle mt-0.5 text-emerald-400" aria-hidden="true"></i> Easy to use interface</li>
-            <li class="flex gap-2"><i class="fas fa-check-circle mt-0.5 text-emerald-400" aria-hidden="true"></i> Truly random assignments</li>
-            <li class="flex gap-2"><i class="fas fa-check-circle mt-0.5 text-emerald-400" aria-hidden="true"></i> Regularly updated faction list</li>
-            <li class="flex gap-2"><i class="fas fa-check-circle mt-0.5 text-emerald-400" aria-hidden="true"></i> Free to use</li>
-        </ul>
-    </div>
-
-    <div class="text-center">
-        <a href="{{ route('home') }}" class="sur-btn-primary min-h-12">Try It Now</a>
-    </div>
-</div>
-
+        <x-sur.reveal :delay="160">
+            <div class="text-center">
+                <a href="{{ route('home') }}" class="sur-btn-primary min-h-12 transition-transform hover:scale-[1.02] active:scale-[0.98]">Try It Now</a>
+            </div>
+        </x-sur.reveal>
+    </x-sur.section>
 </x-layouts.main>

--- a/resources/views/legal/imprint.blade.php
+++ b/resources/views/legal/imprint.blade.php
@@ -1,71 +1,81 @@
 <x-layouts.main>
-    <div class="mx-auto max-w-3xl px-4 pb-16 pt-24 sm:px-6">
-        <h1 class="mb-10 text-3xl font-bold text-white">
-            {{ __('frontend.imprint_header') }}
-        </h1>
+    <x-sur.section :narrow="true">
+        <x-sur.reveal>
+            <h1 class="mb-10 text-3xl font-bold text-white">
+                {{ __('frontend.imprint_header') }}
+            </h1>
+        </x-sur.reveal>
 
-        <div class="sur-card mb-6 border-white/10">
-            <h2 class="mb-3 text-lg font-semibold text-indigo-300">{{ __('frontend.imprint_tmg') }}</h2>
-            <p class="leading-relaxed text-zinc-300">
-                Mike Rauch <br>
-                Im Turmswinkel 12<br>
-                38122 Braunschweig <br>
-            </p>
-        </div>
+        <x-sur.reveal :delay="40">
+            <div class="sur-card mb-6 border-white/10">
+                <h2 class="mb-3 text-lg font-semibold text-indigo-300">{{ __('frontend.imprint_tmg') }}</h2>
+                <p class="leading-relaxed text-zinc-300">
+                    Mike Rauch <br>
+                    Im Turmswinkel 12<br>
+                    38122 Braunschweig <br>
+                </p>
+            </div>
+        </x-sur.reveal>
 
-        <div class="sur-card mb-6 border-white/10">
-            <h2 class="mb-3 text-lg font-semibold text-indigo-300">{{ __('frontend.imprint_represent') }}</h2>
-            <p class="text-zinc-300">Mike Rauch</p>
-        </div>
+        <x-sur.reveal :delay="80">
+            <div class="sur-card mb-6 border-white/10">
+                <h2 class="mb-3 text-lg font-semibold text-indigo-300">{{ __('frontend.imprint_represent') }}</h2>
+                <p class="text-zinc-300">Mike Rauch</p>
+            </div>
+        </x-sur.reveal>
 
-        <div class="sur-card mb-10 border-white/10">
-            <h2 class="mb-3 text-lg font-semibold text-indigo-300">{{ __('frontend.imprint_contact') }}</h2>
-            <p class="mb-2 text-zinc-300">
-                <i class="fas fa-phone-alt me-2 text-indigo-500" aria-hidden="true"></i>{{ __('frontend.imprint_phone') }}: 0531-21939351
-            </p>
-            <p class="text-zinc-300">
-                <i class="fas fa-envelope me-2 text-indigo-500" aria-hidden="true"></i>{{ __('frontend.imprint_email') }}:
-                <a href="mailto:info@smash-up-randomizer.com" class="text-indigo-400 underline decoration-indigo-500/40 underline-offset-2 hover:text-indigo-300">
-                    info@smash-up-randomizer.com
-                </a>
-            </p>
-        </div>
+        <x-sur.reveal :delay="120">
+            <div class="sur-card mb-10 border-white/10">
+                <h2 class="mb-3 text-lg font-semibold text-indigo-300">{{ __('frontend.imprint_contact') }}</h2>
+                <p class="mb-2 text-zinc-300">
+                    <i class="fas fa-phone-alt me-2 text-indigo-500" aria-hidden="true"></i>{{ __('frontend.imprint_phone') }}: 0531-21939351
+                </p>
+                <p class="text-zinc-300">
+                    <i class="fas fa-envelope me-2 text-indigo-500" aria-hidden="true"></i>{{ __('frontend.imprint_email') }}:
+                    <a href="mailto:info@smash-up-randomizer.com" class="text-indigo-400 underline decoration-indigo-500/40 underline-offset-2 hover:text-indigo-300">
+                        info@smash-up-randomizer.com
+                    </a>
+                </p>
+            </div>
+        </x-sur.reveal>
 
-        <h2 class="mb-4 text-xl font-bold text-white">{{ __('frontend.imprint_disclaimer') }}</h2>
+        <x-sur.reveal :delay="160">
+            <h2 class="mb-4 text-xl font-bold text-white">{{ __('frontend.imprint_disclaimer') }}</h2>
 
-        <div class="space-y-2" x-data="{ open: 1 }">
-            <div class="overflow-hidden rounded-xl border border-white/10">
-                <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80"
-                    @click="open = open === 1 ? 0 : 1">
-                    {{ __('frontend.imprint_content_header') }}
-                    <i class="fas fa-chevron-down text-zinc-500 transition" :class="open === 1 && 'rotate-180'"></i>
-                </button>
-                <div x-show="open === 1" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
-                    <p>{{ __('frontend.imprint_content_body') }}</p>
+            <div class="space-y-2" x-data="{ open: 1 }">
+                <div class="overflow-hidden rounded-xl border border-white/10">
+                    <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80"
+                        @click="open = open === 1 ? 0 : 1">
+                        {{ __('frontend.imprint_content_header') }}
+                        <i class="fas fa-chevron-down text-zinc-500 transition" :class="open === 1 && 'rotate-180'"></i>
+                    </button>
+                    <div x-show="open === 1" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
+                        <p>{{ __('frontend.imprint_content_body') }}</p>
+                    </div>
+                </div>
+                <div class="overflow-hidden rounded-xl border border-white/10">
+                    <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80"
+                        @click="open = open === 2 ? 0 : 2">
+                        {{ __('frontend.imprint_copyright_header') }}
+                        <i class="fas fa-chevron-down text-zinc-500 transition" :class="open === 2 && 'rotate-180'"></i>
+                    </button>
+                    <div x-show="open === 2" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
+                        <p>{{ __('frontend.imprint_copyright_body') }}</p>
+                    </div>
+                </div>
+                <div class="overflow-hidden rounded-xl border border-white/10">
+                    <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80"
+                        @click="open = open === 3 ? 0 : 3">
+                        {{ __('frontend.imprint_data_header') }}
+                        <i class="fas fa-chevron-down text-zinc-500 transition" :class="open === 3 && 'rotate-180'"></i>
+                    </button>
+                    <div x-show="open === 3" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
+                        <p class="mb-3">{{ __('frontend.imprint_data_body_1') }}</p>
+                        <p class="mb-3">{{ __('frontend.imprint_data_body_2') }}</p>
+                        <p>{{ __('frontend.imprint_data_body_3') }}</p>
+                    </div>
                 </div>
             </div>
-            <div class="overflow-hidden rounded-xl border border-white/10">
-                <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80"
-                    @click="open = open === 2 ? 0 : 2">
-                    {{ __('frontend.imprint_copyright_header') }}
-                    <i class="fas fa-chevron-down text-zinc-500 transition" :class="open === 2 && 'rotate-180'"></i>
-                </button>
-                <div x-show="open === 2" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
-                    <p>{{ __('frontend.imprint_copyright_body') }}</p>
-                </div>
-            </div>
-            <div class="overflow-hidden rounded-xl border border-white/10">
-                <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80"
-                    @click="open = open === 3 ? 0 : 3">
-                    {{ __('frontend.imprint_data_header') }}
-                    <i class="fas fa-chevron-down text-zinc-500 transition" :class="open === 3 && 'rotate-180'"></i>
-                </button>
-                <div x-show="open === 3" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
-                    <p class="mb-3">{{ __('frontend.imprint_data_body_1') }}</p>
-                    <p class="mb-3">{{ __('frontend.imprint_data_body_2') }}</p>
-                    <p>{{ __('frontend.imprint_data_body_3') }}</p>
-                </div>
-            </div>
-        </div>
-    </div>
+        </x-sur.reveal>
+    </x-sur.section>
 </x-layouts.main>

--- a/resources/views/legal/privacyPolicy.blade.php
+++ b/resources/views/legal/privacyPolicy.blade.php
@@ -1,82 +1,86 @@
 <x-layouts.main>
-    <div class="mx-auto max-w-3xl px-4 pb-16 pt-24 text-zinc-100 sm:px-6" x-data="{ open: 1 }">
-        <div class="sur-card mb-8 border-white/10">
-            <h1 class="mb-4 text-center text-2xl font-bold text-white sm:text-3xl">
-                {{ __('frontend.privacyPolicy_header') }}
-            </h1>
-            <p class="text-center leading-relaxed text-zinc-400">
-                {{ __('frontend.privacyPolicy_teaser') }}
-            </p>
+    <x-sur.section :narrow="true">
+        <div x-data="{ open: 1 }" class="text-zinc-100">
+            <x-sur.reveal>
+                <div class="sur-card mb-8 border-white/10">
+                    <h1 class="mb-4 text-center text-2xl font-bold text-white sm:text-3xl">
+                        {{ __('frontend.privacyPolicy_header') }}
+                    </h1>
+                    <p class="text-center leading-relaxed text-zinc-400">
+                        {{ __('frontend.privacyPolicy_teaser') }}
+                    </p>
 
-            <div class="mt-8 space-y-2">
-                <div class="overflow-hidden rounded-xl border border-white/10">
-                    <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
-                        @click="open = open === 1 ? 0 : 1"
-                        :aria-expanded="open === 1">
-                        {{ __('frontend.privacyPolicy_dataCollection_header') }}
-                        <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 1 && 'rotate-180'"></i>
-                    </button>
-                    <div x-show="open === 1" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
-                        <p class="mb-3">{{ __('frontend.privacyPolicy_dataCollection_body') }}</p>
-                        <p class="mb-3">{{ __('frontend.privacyPolicy_consent_body') }}</p>
-                        <p>{{ __('frontend.privacyPolicy_matomo_body') }}</p>
+                    <div class="mt-8 space-y-2">
+                        <div class="overflow-hidden rounded-xl border border-white/10">
+                            <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
+                                @click="open = open === 1 ? 0 : 1"
+                                :aria-expanded="open === 1">
+                                {{ __('frontend.privacyPolicy_dataCollection_header') }}
+                                <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 1 && 'rotate-180'"></i>
+                            </button>
+                            <div x-show="open === 1" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
+                                <p class="mb-3">{{ __('frontend.privacyPolicy_dataCollection_body') }}</p>
+                                <p class="mb-3">{{ __('frontend.privacyPolicy_consent_body') }}</p>
+                                <p>{{ __('frontend.privacyPolicy_matomo_body') }}</p>
+                            </div>
+                        </div>
+
+                        <div class="overflow-hidden rounded-xl border border-white/10">
+                            <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
+                                @click="open = open === 2 ? 0 : 2"
+                                :aria-expanded="open === 2">
+                                {{ __('frontend.privacyPolicy_security_header') }}
+                                <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 2 && 'rotate-180'"></i>
+                            </button>
+                            <div x-show="open === 2" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
+                                <p>{{ __('frontend.privacyPolicy_security_body') }}</p>
+                            </div>
+                        </div>
+
+                        <div class="overflow-hidden rounded-xl border border-white/10">
+                            <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
+                                @click="open = open === 3 ? 0 : 3"
+                                :aria-expanded="open === 3">
+                                {{ __('frontend.privacyPolicy_cookies_header') }}
+                                <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 3 && 'rotate-180'"></i>
+                            </button>
+                            <div x-show="open === 3" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
+                                <p class="mb-3">{{ __('frontend.privacyPolicy_cookies_body') }}</p>
+                                <p>{{ __('frontend.privacyPolicy_consent_cookies_body') }}</p>
+                            </div>
+                        </div>
+
+                        <div class="overflow-hidden rounded-xl border border-white/10">
+                            <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
+                                @click="open = open === 4 ? 0 : 4"
+                                :aria-expanded="open === 4">
+                                {{ __('frontend.privacyPolicy_rights_header') }}
+                                <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 4 && 'rotate-180'"></i>
+                            </button>
+                            <div x-show="open === 4" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
+                                <p>{{ __('frontend.privacyPolicy_rights_body') }}</p>
+                            </div>
+                        </div>
+
+                        <div class="overflow-hidden rounded-xl border border-white/10">
+                            <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
+                                @click="open = open === 5 ? 0 : 5"
+                                :aria-expanded="open === 5">
+                                {{ __('frontend.privacyPolicy_dataSharing_header') }}
+                                <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 5 && 'rotate-180'"></i>
+                            </button>
+                            <div x-show="open === 5" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
+                                <p class="mb-3">{{ __('frontend.privacyPolicy_dataSharing_body') }}</p>
+                                <p>{{ __('frontend.privacyPolicy_matomo_dataSharing_body') }}</p>
+                            </div>
+                        </div>
                     </div>
-                </div>
 
-                <div class="overflow-hidden rounded-xl border border-white/10">
-                    <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
-                        @click="open = open === 2 ? 0 : 2"
-                        :aria-expanded="open === 2">
-                        {{ __('frontend.privacyPolicy_security_header') }}
-                        <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 2 && 'rotate-180'"></i>
-                    </button>
-                    <div x-show="open === 2" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
-                        <p>{{ __('frontend.privacyPolicy_security_body') }}</p>
-                    </div>
+                    <p class="mt-8 text-center text-sm text-zinc-500">
+                        {{ __('frontend.privacyPolicy_lastWords') }}
+                    </p>
                 </div>
-
-                <div class="overflow-hidden rounded-xl border border-white/10">
-                    <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
-                        @click="open = open === 3 ? 0 : 3"
-                        :aria-expanded="open === 3">
-                        {{ __('frontend.privacyPolicy_cookies_header') }}
-                        <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 3 && 'rotate-180'"></i>
-                    </button>
-                    <div x-show="open === 3" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
-                        <p class="mb-3">{{ __('frontend.privacyPolicy_cookies_body') }}</p>
-                        <p>{{ __('frontend.privacyPolicy_consent_cookies_body') }}</p>
-                    </div>
-                </div>
-
-                <div class="overflow-hidden rounded-xl border border-white/10">
-                    <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
-                        @click="open = open === 4 ? 0 : 4"
-                        :aria-expanded="open === 4">
-                        {{ __('frontend.privacyPolicy_rights_header') }}
-                        <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 4 && 'rotate-180'"></i>
-                    </button>
-                    <div x-show="open === 4" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
-                        <p>{{ __('frontend.privacyPolicy_rights_body') }}</p>
-                    </div>
-                </div>
-
-                <div class="overflow-hidden rounded-xl border border-white/10">
-                    <button type="button" class="flex w-full items-center justify-between gap-3 bg-zinc-900/80 px-4 py-4 text-left text-sm font-semibold text-white transition hover:bg-zinc-800/80 sm:text-base"
-                        @click="open = open === 5 ? 0 : 5"
-                        :aria-expanded="open === 5">
-                        {{ __('frontend.privacyPolicy_dataSharing_header') }}
-                        <i class="fas fa-chevron-down shrink-0 text-zinc-500 transition" :class="open === 5 && 'rotate-180'"></i>
-                    </button>
-                    <div x-show="open === 5" x-transition class="border-t border-white/10 bg-zinc-950/60 px-4 py-4 text-sm leading-relaxed text-zinc-300">
-                        <p class="mb-3">{{ __('frontend.privacyPolicy_dataSharing_body') }}</p>
-                        <p>{{ __('frontend.privacyPolicy_matomo_dataSharing_body') }}</p>
-                    </div>
-                </div>
-            </div>
-
-            <p class="mt-8 text-center text-sm text-zinc-500">
-                {{ __('frontend.privacyPolicy_lastWords') }}
-            </p>
+            </x-sur.reveal>
         </div>
-    </div>
+    </x-sur.section>
 </x-layouts.main>

--- a/resources/views/shuffle/shuffle-decks.blade.php
+++ b/resources/views/shuffle/shuffle-decks.blade.php
@@ -1,36 +1,36 @@
 <x-layouts.main>
     <div id="hero-header" class="flex min-h-screen flex-col">
-        <div class="relative w-full flex-1 overflow-hidden">
-            <div class="bg-options min-h-screen" id="hero-js" style="background-image: url('{{ asset('images/result.png') }}'); background-position: center; background-size: cover;">
-                <div class="mx-auto max-w-7xl px-4 py-12 pt-24 sm:px-6">
-                    <h1 class="mb-10 text-center text-3xl font-bold text-white drop-shadow-lg animate__animated animate__fadeInDown sm:text-4xl">{{ __('frontend.shuffle_results') }}</h1>
-                    <div class="grid gap-6 md:grid-cols-2">
-                        @foreach ($selectedDecks as $playerDecks)
-                        <div class="animate__animated animate__fadeInUp" style="animation-delay: {{ $loop->index * 0.2 }}s;">
-                            <div class="sur-card overflow-hidden border-indigo-500/20 p-0">
-                                <div class="bg-linear-to-r from-indigo-700 via-indigo-600 to-violet-600 px-4 py-3 text-center">
-                                    <h2 class="text-lg font-bold text-white">
-                                        {{ __('frontend.player') }} {{ $loop->iteration }}
-                                    </h2>
-                                </div>
-                                <div class="p-4">
-                                    <div class="grid grid-cols-2 gap-3">
-                                        @foreach ($playerDecks as $deck)
-                                        <div class="rounded-full border border-white/10 bg-zinc-100 px-3 py-2 text-center text-sm font-semibold text-zinc-900">
-                                            <span>{{ $deck['name'] }}</span>
-                                        </div>
-                                        @endforeach
+        <x-sur.hero :image="asset('images/result.png')" bg-id="hero-js" min-class="min-h-screen">
+            <div class="mx-auto w-full max-w-7xl py-12 pt-24">
+                <x-sur.reveal>
+                    <h1 class="mb-10 text-center text-3xl font-bold text-white drop-shadow-lg sm:text-4xl">{{ __('frontend.shuffle_results') }}</h1>
+                </x-sur.reveal>
+                <div class="grid gap-6 md:grid-cols-2">
+                    @foreach ($selectedDecks as $playerDecks)
+                    <x-sur.reveal :delay="$loop->index * 70">
+                        <div class="sur-card overflow-hidden border-indigo-500/20 p-0">
+                            <div class="bg-linear-to-r from-indigo-700 via-indigo-600 to-violet-600 px-4 py-3 text-center">
+                                <h2 class="text-lg font-bold text-white">
+                                    {{ __('frontend.player') }} {{ $loop->iteration }}
+                                </h2>
+                            </div>
+                            <div class="p-4">
+                                <div class="grid grid-cols-2 gap-3">
+                                    @foreach ($playerDecks as $deck)
+                                    <div class="rounded-full border border-white/10 bg-zinc-100 px-3 py-2 text-center text-sm font-semibold text-zinc-900">
+                                        <span>{{ $deck['name'] }}</span>
                                     </div>
+                                    @endforeach
                                 </div>
                             </div>
                         </div>
-                        @endforeach
-                    </div>
-                    <div class="mt-12 text-center">
-                        <a href="{{ route('home') }}" class="sur-btn-primary inline-flex min-h-12 animate__animated animate__pulse animate__infinite">{{ __('frontend.shuffle_again') }}</a>
-                    </div>
+                    </x-sur.reveal>
+                    @endforeach
+                </div>
+                <div class="mt-12 text-center">
+                    <a href="{{ route('home') }}" class="sur-btn-primary inline-flex min-h-12 transition-transform hover:scale-[1.02] active:scale-[0.98]">{{ __('frontend.shuffle_again') }}</a>
                 </div>
             </div>
-        </div>
+        </x-sur.hero>
     </div>
 </x-layouts.main>

--- a/resources/views/start/home.blade.php
+++ b/resources/views/start/home.blade.php
@@ -1,45 +1,46 @@
 <x-layouts.main>
-    <div id="hero-header" class="animate__animated animate__fadeIn">
-        <div class="relative w-full overflow-hidden">
-            <div class="hero-height bg-options min-h-[70vh] sm:min-h-[80vh]" id="hero-js" style="background-image: url('{{ asset('images/smashup_hero.png') }}')">
-                <div class="mx-auto flex h-full max-w-7xl items-center px-4 sm:px-6">
-                    <div class="w-full py-8 sm:py-12">
-                        <div class="max-w-xl rounded-2xl border border-white/10 bg-black/70 p-6 shadow-2xl backdrop-blur-md animate__animated animate__slideInLeft sm:p-8">
-                            <h1 class="mb-4 text-3xl font-extrabold tracking-tight text-white sm:text-4xl md:text-5xl">
-                                {{ __('frontend.start_header') }}
-                            </h1>
-                            <p class="text-base leading-relaxed text-zinc-200 sm:text-lg">
-                                {{ __('frontend.start_teaser') }}
-                            </p>
-                        </div>
+    <x-sur.hero :image="asset('images/smashup_hero.png')" bg-id="hero-js" id="hero-header">
+        <div class="w-full py-8 sm:py-12">
+            <x-sur.reveal>
+                <x-sur.panel>
+                    <h1 class="mb-4 text-3xl font-extrabold tracking-tight text-white sm:text-4xl md:text-5xl">
+                        {{ __('frontend.start_header') }}
+                    </h1>
+                    <p class="text-base leading-relaxed text-zinc-200 sm:text-lg">
+                        {{ __('frontend.start_teaser') }}
+                    </p>
+                </x-sur.panel>
+            </x-sur.reveal>
+        </div>
+    </x-sur.hero>
+
+    <x-sur.section>
+        <div class="grid gap-6 md:grid-cols-2">
+            <x-sur.reveal :delay="0">
+                <div class="sur-card-interactive h-full p-6 sm:p-8">
+                    <h2 class="mb-4 text-xl font-bold text-white sm:text-2xl">
+                        {{ __('frontend.help_smashup_header') }}
+                    </h2>
+                    <p class="mb-3 text-sm leading-relaxed text-zinc-300">{{ __('frontend.help_smashup_body') }}</p>
+                    <p class="text-sm leading-relaxed text-zinc-300">{{ __('frontend.help_smashup_function') }}</p>
+                </div>
+            </x-sur.reveal>
+            <x-sur.reveal :delay="90">
+                <div class="sur-card-interactive flex h-full flex-col p-6 sm:p-8">
+                    <h2 class="mb-4 text-xl font-bold text-white sm:text-2xl">
+                        {{ __('frontend.help_howto_header') }}
+                    </h2>
+                    <p class="mb-3 text-sm leading-relaxed text-zinc-300">{{ __('frontend.help_howto_body') }}</p>
+                    <p class="mb-6 text-sm leading-relaxed text-zinc-300">{{ __('frontend.help_howto_fun') }}</p>
+                    <div class="mt-auto text-center">
+                        <button type="button" id="open-shuffle-modal" class="sur-btn-primary w-full min-h-12 transition-transform hover:scale-[1.02] active:scale-[0.98] sm:w-auto">
+                            {{ __('frontend.shuffle_button') }}
+                        </button>
                     </div>
                 </div>
-            </div>
+            </x-sur.reveal>
         </div>
-    </div>
-    <div class="mx-auto max-w-7xl px-4 py-10 sm:px-6">
-        <div class="grid gap-6 md:grid-cols-2">
-            <div class="sur-card-interactive animate__animated animate__fadeInLeft p-6 sm:p-8">
-                <h2 class="mb-4 text-xl font-bold text-white sm:text-2xl">
-                    {{ __('frontend.help_smashup_header') }}
-                </h2>
-                <p class="mb-3 text-sm leading-relaxed text-zinc-300">{{ __('frontend.help_smashup_body') }}</p>
-                <p class="text-sm leading-relaxed text-zinc-300">{{ __('frontend.help_smashup_function') }}</p>
-            </div>
-            <div class="sur-card-interactive animate__animated animate__fadeInRight p-6 sm:p-8">
-                <h2 class="mb-4 text-xl font-bold text-white sm:text-2xl">
-                    {{ __('frontend.help_howto_header') }}
-                </h2>
-                <p class="mb-3 text-sm leading-relaxed text-zinc-300">{{ __('frontend.help_howto_body') }}</p>
-                <p class="mb-6 text-sm leading-relaxed text-zinc-300">{{ __('frontend.help_howto_fun') }}</p>
-                <div class="text-center">
-                    <button type="button" id="open-shuffle-modal" class="sur-btn-primary w-full min-h-12 animate__animated animate__pulse animate__infinite sm:w-auto">
-                        {{ __('frontend.shuffle_button') }}
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
+    </x-sur.section>
 
     <dialog id="shuffle-modal" aria-labelledby="shuffleModalTitle" class="shadow-2xl">
         <div class="flex max-h-[90vh] flex-col">
@@ -54,16 +55,16 @@
                 @csrf
                 <div class="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
                     <div class="sur-progress-track mb-4">
-                        <div class="sur-progress-fill progress-bar" style="width: 33%;" role="progressbar" aria-valuenow="33" aria-valuemin="0" aria-valuemax="100">Step 1 of 3</div>
+                        <div class="sur-progress-fill shuffle-progress-bar progress-bar" style="width: 33%;" role="progressbar" aria-valuenow="33" aria-valuemin="0" aria-valuemax="100">Step 1 of 3</div>
                     </div>
 
                     <div class="mb-6 flex justify-between gap-2 text-xs text-zinc-500 sm:text-sm">
-                        <span class="step-label active font-medium text-indigo-400">Number of Players</span>
-                        <span class="step-label">Include Factions</span>
-                        <span class="step-label">Exclude Factions</span>
+                        <span class="shuffle-step-label active font-medium text-indigo-400">Number of Players</span>
+                        <span class="shuffle-step-label">Include Factions</span>
+                        <span class="shuffle-step-label">Exclude Factions</span>
                     </div>
 
-                    <div class="step-content" id="step1-content">
+                    <div class="shuffle-step-content" id="step1-content">
                         <h3 class="mb-3 text-base font-semibold text-white sm:text-lg">Step 1: Number of Players</h3>
                         <div class="mb-4">
                             <label for="numberOfPlayers" class="mb-2 block text-sm text-zinc-300">{{ __('frontend.number_players') }}</label>
@@ -77,7 +78,7 @@
                         <button type="button" class="sur-btn-primary next-step">Next</button>
                     </div>
 
-                    <div class="step-content hidden" id="step2-content">
+                    <div class="shuffle-step-content hidden" id="step2-content">
                         <h3 class="mb-3 text-base font-semibold text-white sm:text-lg">Step 2: Include Factions</h3>
                         <div class="mb-4">
                             <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
@@ -101,7 +102,7 @@
                         </div>
                     </div>
 
-                    <div class="step-content hidden" id="step3-content">
+                    <div class="shuffle-step-content hidden" id="step3-content">
                         <h3 class="mb-3 text-base font-semibold text-white sm:text-lg">Step 3: Exclude Factions</h3>
                         <div class="mb-4">
                             <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
@@ -132,72 +133,6 @@
     </dialog>
 </x-layouts.main>
 
-<style>
-    .hero-height {
-        background-size: cover;
-        background-position: center;
-    }
-    .bg-options {
-        background-repeat: no-repeat;
-        background-position: center;
-    }
-    .hover-card {
-        transition: transform 0.3s ease-in-out;
-    }
-    .hover-card:hover {
-        transform: translateY(-5px);
-    }
-    .animate__animated {
-        animation-duration: 0.5s;
-    }
-    .progress-bar {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 0.75rem;
-        font-weight: 600;
-        color: #eef2ff;
-    }
-    .step-labels {
-        display: flex;
-        justify-content: space-between;
-    }
-    .step-label {
-        flex: 1;
-        text-align: center;
-        color: #71717a;
-    }
-    .step-label.active {
-        color: #a5b4fc;
-        font-weight: 600;
-    }
-    .faction-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-        gap: 0.5rem;
-    }
-    @media (min-width: 640px) {
-        .faction-grid {
-            grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-            gap: 0.625rem;
-        }
-    }
-    .faction-item {
-        text-align: center;
-    }
-    .step-content {
-        transition: opacity 0.3s ease, transform 0.3s ease;
-    }
-    .step-content.slide-out {
-        opacity: 0;
-        transform: translateX(-100%);
-    }
-    .step-content.slide-in {
-        opacity: 1;
-        transform: translateX(0);
-    }
-</style>
-
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         const shuffleDialog = document.getElementById('shuffle-modal');
@@ -211,16 +146,11 @@
             btn.addEventListener('click', () => shuffleDialog?.close());
         });
 
-        const cards = document.querySelectorAll('.hover-card');
-        cards.forEach((card, index) => {
-            card.style.animationDelay = `${index * 0.2}s`;
-        });
-
-        const contents = document.querySelectorAll('.step-content');
+        const contents = document.querySelectorAll('.shuffle-step-content');
         const nextButtons = document.querySelectorAll('.next-step');
         const prevButtons = document.querySelectorAll('.prev-step');
         const progressBar = document.querySelector('.progress-bar');
-        const stepLabels = document.querySelectorAll('.step-label');
+        const stepLabels = document.querySelectorAll('.shuffle-step-label');
 
         function updateProgress(step) {
             if (!progressBar) return;
@@ -253,7 +183,7 @@
 
         nextButtons.forEach((button) => {
             button.addEventListener('click', () => {
-                const currentStep = document.querySelector('.step-content:not(.hidden)');
+                const currentStep = document.querySelector('.shuffle-step-content:not(.hidden)');
                 const currentIndex = Array.from(contents).indexOf(currentStep);
                 if (currentIndex < contents.length - 1) {
                     animateContentChange(currentStep, contents[currentIndex + 1]);
@@ -264,7 +194,7 @@
 
         prevButtons.forEach((button) => {
             button.addEventListener('click', () => {
-                const currentStep = document.querySelector('.step-content:not(.hidden)');
+                const currentStep = document.querySelector('.shuffle-step-content:not(.hidden)');
                 const currentIndex = Array.from(contents).indexOf(currentStep);
                 if (currentIndex > 0) {
                     animateContentChange(currentStep, contents[currentIndex - 1]);


### PR DESCRIPTION
## Summary
Introduces reusable `x-sur.*` Blade components (container, section, hero, glass panel, page heading, scroll reveal) and registers `@alpinejs/intersect` for in-view motion. Main layout gains `#main-content`, skip link (EN/DE), and footer stagger. Public and key backend views refactored; shuffle wizard styles moved to `app.css`; Alpine bumped to 3.15.x.

## Roadmap
Updated (Shipped table).

## Public copy
CHANGELOG + `skip_to_content` strings in `lang/*` and `resources/lang/en/frontend.php`.

## Testing
- `ddev exec npm run build`
- `ddev exec php artisan test` (all green)


Made with [Cursor](https://cursor.com)