### PR TITLE
fix: themed scrollbar on faction detail scroll container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
+- **Faction detail:** The full-page scroll container now uses a visible scrollbar styled to match the indigo/violet dark UI (Firefox `scrollbar-color`, WebKit gradient thumb/track) instead of hiding it.
 - **Public shell:** Header and footer redesigned (pill navigation with active route states, scroll elevation, full-width mobile panel with primary CTA; footer columns for brand, explore, legal, and community links + copyright bar). Navigation and footer copy use `frontend.*` translations (EN/DE).
 - **Branding:** New vector logo (`public/images/brand/logo-mark.svg`, indigo/violet card-stack motif) used in public and backend nav; favicons and touch icons regenerated from the artwork; PWA manifest paths and theme colors aligned with the dark UI; Open Graph / Twitter preview image uses the 512×512 app icon.
 - **Frontend layout:** Blade views use shared `x-sur.*` components (container, section, hero, panel, page heading, scroll reveal) with `@alpinejs/intersect` for in-view motion; main landmark skip link; footer column entrance animation; shuffle wizard styles consolidated in `app.css`. Primary CTAs no longer use infinite pulse animations.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -389,3 +389,48 @@
     opacity: 1;
     transform: translateX(0);
 }
+
+/*
+ * Faction detail — full-height scroll container (scroll-snap + themed scrollbar).
+ */
+.scroll-container {
+    height: 100vh;
+    overflow-y: scroll;
+    scroll-snap-type: y mandatory;
+    scroll-behavior: smooth;
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(129, 140, 248, 0.7) rgba(24, 24, 27, 0.92);
+}
+
+.scroll-container::-webkit-scrollbar {
+    width: 11px;
+}
+
+.scroll-container::-webkit-scrollbar-track {
+    background: linear-gradient(180deg, rgba(24, 24, 27, 0.96), rgba(9, 9, 11, 0.99));
+    border-left: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.scroll-container::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    border: 2px solid rgba(9, 9, 11, 0.92);
+    background: linear-gradient(180deg, rgba(99, 102, 241, 0.92), rgba(124, 58, 237, 0.88));
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.14),
+        0 0 14px rgba(99, 102, 241, 0.2);
+}
+
+.scroll-container::-webkit-scrollbar-thumb:hover {
+    background: linear-gradient(180deg, rgba(129, 140, 248, 0.98), rgba(139, 92, 246, 0.92));
+}
+
+.scroll-container::-webkit-scrollbar-thumb:active {
+    background: linear-gradient(180deg, rgba(99, 102, 241, 1), rgba(109, 40, 217, 0.95));
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .scroll-container {
+        scroll-behavior: auto;
+    }
+}

--- a/resources/views/decks/detail.blade.php
+++ b/resources/views/decks/detail.blade.php
@@ -130,20 +130,6 @@
         overflow-x: hidden;
     }
 
-    .scroll-container {
-        height: 100vh;
-        overflow-y: scroll;
-        scroll-snap-type: y mandatory;
-        scroll-behavior: smooth;
-        scrollbar-width: none;
-        -ms-overflow-style: none;
-    }
-
-    .scroll-container::-webkit-scrollbar {
-        width: 0;
-        height: 0;
-    }
-
     .scroll-section {
         scroll-snap-align: start;
         position: relative;


### PR DESCRIPTION
Replaces hidden scrollbar with a thin indigo→violet gradient thumb and zinc track; `scrollbar-gutter: stable`; reduced-motion keeps `scroll-behavior: auto`. Styles live in `app.css`; inline duplicate removed from `decks/detail.blade.php`.

Made with [Cursor](https://cursor.com)