### PR TITLE
feat: global themed scrollbars (html + utility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
-- **Faction detail:** The full-page scroll container now uses a visible scrollbar styled to match the indigo/violet dark UI (Firefox `scrollbar-color`, WebKit gradient thumb/track) instead of hiding it.
+- **Scrollbars:** Document-wide (`html`) scrollbar uses shared SUR-themed styling (indigo/violet gradient thumb, zinc track with indigo hairline, glow). The same chrome applies to `.scroll-container` (faction detail), and the utility class `.sur-scrollbar` is used on scrollable regions (e.g. shuffle modal body, cookie preference panel).
+- **Faction detail:** Full-page scroll container uses the global scrollbar theme (see above) instead of hiding the scrollbar.
 - **Public shell:** Header and footer redesigned (pill navigation with active route states, scroll elevation, full-width mobile panel with primary CTA; footer columns for brand, explore, legal, and community links + copyright bar). Navigation and footer copy use `frontend.*` translations (EN/DE).
 - **Branding:** New vector logo (`public/images/brand/logo-mark.svg`, indigo/violet card-stack motif) used in public and backend nav; favicons and touch icons regenerated from the artwork; PWA manifest paths and theme colors aligned with the dark UI; Open Graph / Twitter preview image uses the 512×512 app icon.
 - **Frontend layout:** Blade views use shared `x-sur.*` components (container, section, hero, panel, page heading, scroll reveal) with `@alpinejs/intersect` for in-view motion; main landmark skip link; footer column entrance animation; shuffle wizard styles consolidated in `app.css`. Primary CTAs no longer use infinite pulse animations.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@ High-level product and engineering priorities. Update this file in the same PR w
 
 | Area     | Notes                                                                        |
 | -------- | ---------------------------------------------------------------------------- |
-| Core app | Laravel 13, Blade, Vite, **Tailwind CSS 4** (dark-first UI), Alpine.js (`sur-*` layout components, scroll-reveal), bilingual frontend strings; modern public header/footer (pill nav, footer columns) |
+| Core app | Laravel 13, Blade, Vite, **Tailwind CSS 4** (dark-first UI), Alpine.js (`sur-*` layout components, scroll-reveal), bilingual frontend strings; modern public header/footer (pill nav, footer columns); custom global scrollbar (indigo/violet “SUR” thumb + zinc track, `.sur-scrollbar` utility) |
 | Branding | SVG logo mark + generated favicons / touch icons; manifest paths under `/images/favicons/` |
 | Privacy  | First-party cookie UI (bottom strip + preference modal); web analytics via **self-hosted Matomo** (`analytics.kadsuno.com`) only after opt-in, configurable (see `config/matomo.php`, CHANGELOG) |
 | Ops      | Optional **Sentry** error reporting (`sentry/sentry-laravel`, `SENTRY_LARAVEL_DSN`, `config/sentry.php`); transactional email via Laravel mailer — **SMTP** (`MAIL_*`) or **Brevo API** (`MAIL_MAILER=brevo`, `BREVO_API_KEY`, same pattern as Issue Forge; see README) |

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -15,6 +15,91 @@
  * Design tokens: dark-first, mobile-first. Accent: indigo / violet (SaaS-style).
  */
 
+/*
+ * Global scrollbar (document + opt-in). Firefox: scrollbar-color; WebKit: pseudo-elements.
+ * “SUR” thumb: diagonal indigo→violet gradient, lit edge, soft outer glow — track: deep zinc + indigo hairline.
+ */
+:root {
+    --sur-scrollbar-w: 12px;
+    --sur-scrollbar-fg: rgba(165, 180, 252, 0.95);
+    --sur-scrollbar-bg: rgba(10, 10, 13, 0.98);
+}
+
+html {
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+    scrollbar-color: var(--sur-scrollbar-fg) var(--sur-scrollbar-bg);
+}
+
+html::-webkit-scrollbar,
+.scroll-container::-webkit-scrollbar,
+.sur-scrollbar::-webkit-scrollbar {
+    width: var(--sur-scrollbar-w);
+    height: var(--sur-scrollbar-w);
+}
+
+html::-webkit-scrollbar-track,
+.scroll-container::-webkit-scrollbar-track,
+.sur-scrollbar::-webkit-scrollbar-track {
+    background: linear-gradient(
+        180deg,
+        rgba(24, 24, 27, 0.99) 0%,
+        rgba(9, 9, 11, 1) 45%,
+        rgba(18, 18, 22, 0.98) 100%
+    );
+    border-left: 1px solid rgba(99, 102, 241, 0.14);
+    box-shadow: inset 3px 0 12px rgba(0, 0, 0, 0.4);
+}
+
+html::-webkit-scrollbar-thumb,
+.scroll-container::-webkit-scrollbar-thumb,
+.sur-scrollbar::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    border: 2px solid rgba(8, 8, 10, 0.95);
+    background: linear-gradient(
+        165deg,
+        rgba(224, 231, 255, 0.55) 0%,
+        rgba(129, 140, 248, 0.98) 28%,
+        rgba(99, 102, 241, 1) 55%,
+        rgba(124, 58, 237, 0.96) 100%
+    );
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.22),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.25),
+        0 0 0 1px rgba(99, 102, 241, 0.28),
+        0 2px 18px rgba(99, 102, 241, 0.28);
+}
+
+html::-webkit-scrollbar-thumb:hover,
+.scroll-container::-webkit-scrollbar-thumb:hover,
+.sur-scrollbar::-webkit-scrollbar-thumb:hover {
+    background: linear-gradient(
+        165deg,
+        rgba(238, 242, 255, 0.75) 0%,
+        rgba(165, 180, 252, 1) 30%,
+        rgba(129, 140, 248, 1) 60%,
+        rgba(167, 139, 250, 0.98) 100%
+    );
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.3),
+        0 0 0 1px rgba(165, 180, 252, 0.45),
+        0 4px 22px rgba(99, 102, 241, 0.4);
+}
+
+html::-webkit-scrollbar-thumb:active,
+.scroll-container::-webkit-scrollbar-thumb:active,
+.sur-scrollbar::-webkit-scrollbar-thumb:active {
+    background: linear-gradient(180deg, rgba(67, 56, 202, 1) 0%, rgba(109, 40, 217, 0.98) 100%);
+    box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.scroll-container,
+.sur-scrollbar {
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+    scrollbar-color: var(--sur-scrollbar-fg) var(--sur-scrollbar-bg);
+}
+
 @layer base {
     html {
         @apply scroll-smooth;
@@ -391,42 +476,13 @@
 }
 
 /*
- * Faction detail — full-height scroll container (scroll-snap + themed scrollbar).
+ * Faction detail — full-height scroll container (scroll-snap). Thumb/track match global SUR scrollbar above.
  */
 .scroll-container {
     height: 100vh;
     overflow-y: scroll;
     scroll-snap-type: y mandatory;
     scroll-behavior: smooth;
-    scrollbar-gutter: stable;
-    scrollbar-width: thin;
-    scrollbar-color: rgba(129, 140, 248, 0.7) rgba(24, 24, 27, 0.92);
-}
-
-.scroll-container::-webkit-scrollbar {
-    width: 11px;
-}
-
-.scroll-container::-webkit-scrollbar-track {
-    background: linear-gradient(180deg, rgba(24, 24, 27, 0.96), rgba(9, 9, 11, 0.99));
-    border-left: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.scroll-container::-webkit-scrollbar-thumb {
-    border-radius: 9999px;
-    border: 2px solid rgba(9, 9, 11, 0.92);
-    background: linear-gradient(180deg, rgba(99, 102, 241, 0.92), rgba(124, 58, 237, 0.88));
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.14),
-        0 0 14px rgba(99, 102, 241, 0.2);
-}
-
-.scroll-container::-webkit-scrollbar-thumb:hover {
-    background: linear-gradient(180deg, rgba(129, 140, 248, 0.98), rgba(139, 92, 246, 0.92));
-}
-
-.scroll-container::-webkit-scrollbar-thumb:active {
-    background: linear-gradient(180deg, rgba(99, 102, 241, 1), rgba(109, 40, 217, 0.95));
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/resources/views/components/cookie-banner.blade.php
+++ b/resources/views/components/cookie-banner.blade.php
@@ -60,7 +60,7 @@
                     <span class="text-xl leading-none" aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div class="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            <div class="sur-scrollbar min-h-0 flex-1 overflow-y-auto px-5 py-4">
                 <p class="mb-4 text-sm text-zinc-400">{{ __('frontend.cookie_banner_settings_intro') }}</p>
 
                 <div class="sur-cookie-category">

--- a/resources/views/start/home.blade.php
+++ b/resources/views/start/home.blade.php
@@ -53,7 +53,7 @@
 
             <form class="needs-validation flex min-h-0 flex-1 flex-col" method="POST" action="{{ route('shuffle-result') }}" novalidate>
                 @csrf
-                <div class="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+                <div class="sur-scrollbar min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
                     <div class="sur-progress-track mb-4">
                         <div class="sur-progress-fill shuffle-progress-bar progress-bar" style="width: 33%;" role="progressbar" aria-valuenow="33" aria-valuemin="0" aria-valuemax="100">Step 1 of 3</div>
                     </div>


### PR DESCRIPTION
Adds document-wide `html` scrollbar styling (Firefox `scrollbar-color`, WebKit gradient thumb/track with indigo hairline + glow). `.scroll-container` reuses the same chrome. New `.sur-scrollbar` on shuffle modal scroll body and cookie settings panel. Tokens: `:root --sur-scrollbar-*`.

Made with [Cursor](https://cursor.com)