### PR TITLE
fix: shuffle modal stuck backdrop after last faction interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 
 - **Shuffle modal:** Toggling include/exclude faction chips could paint the dialog contents **solid black** (GPU compositing with `backdrop-blur` + Tailwind `peer` variants). Removed blur layers on the modal card/footer, switched checked styling to **`:has()`** on `.faction-item`, renamed the form class to `shuffle-wizard-form` (no `needs-validation`), added `overflow-anchor: none` on the scroll region and `isolate` on the card.
+- **Shuffle modal:** On the last faction rows, **Enter** could trigger **implicit form submit** while the submit button was only `hidden` (still the default submit control), closing/navigating with a **stuck blurred `::backdrop`** in some browsers. The submit control is now **`disabled` unless step 3 is active**, `::backdrop` uses a **solid dim** (no `backdrop-filter`), plus **Enter** on checkboxes is suppressed and a light **`close` reflow** hook was added.
 - Add `sessions` and `cache` / `cache_locks` migrations for apps using `SESSION_DRIVER=database` and database-backed cache (Laravel 13 default-style tables).
 
 ### Changed

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -325,8 +325,8 @@ html::-webkit-scrollbar-thumb:active,
     }
 
     #shuffle-modal::backdrop {
-        background: rgba(9, 9, 11, 0.82);
-        backdrop-filter: blur(10px);
+        /* No backdrop-filter: compositor can leave blur visible after close(); solid dim only */
+        background: rgba(9, 9, 11, 0.88);
     }
 
     .sur-progress-track {
@@ -450,6 +450,8 @@ html::-webkit-scrollbar-thumb:active,
 
 .shuffle-modal-scroll {
     overflow-anchor: none;
+    overscroll-behavior: contain;
+    padding-bottom: max(1.5rem, env(safe-area-inset-bottom, 0px));
 }
 
 .shuffle-wizard-stepper ol {

--- a/resources/views/start/home.blade.php
+++ b/resources/views/start/home.blade.php
@@ -248,7 +248,7 @@
                 </div>
             </div>
 
-            <form class="shuffle-wizard-form flex min-h-0 flex-1 flex-col" method="POST" action="{{ route('shuffle-result') }}" novalidate>
+            <form id="shuffle-wizard-form" class="shuffle-wizard-form flex min-h-0 flex-1 flex-col" method="POST" action="{{ route('shuffle-result') }}" novalidate>
                 @csrf
                 <div class="shuffle-modal-scroll sur-scrollbar min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-5 py-6 sm:px-8 sm:py-8">
                     <div class="mb-6 flex flex-wrap items-center justify-between gap-3">
@@ -340,7 +340,7 @@
                         <button type="button" id="shuffle-next" class="sur-btn-primary min-h-12 w-full min-w-[10rem] sm:w-auto">
                             {{ __('frontend.shuffle_wizard_next') }}
                         </button>
-                        <button type="submit" id="shuffle-submit" class="sur-btn-primary inline-flex min-h-12 w-full items-center justify-center gap-2 min-w-[10rem] sm:w-auto" hidden>
+                        <button type="submit" id="shuffle-submit" class="sur-btn-primary inline-flex min-h-12 w-full items-center justify-center gap-2 min-w-[10rem] sm:w-auto" hidden disabled>
                             <i class="fa-solid fa-shuffle" aria-hidden="true"></i>{{ __('frontend.shuffle_wizard_run') }}
                         </button>
                     </div>
@@ -389,7 +389,9 @@
                 nextBtn.hidden = step >= totalSteps;
             }
             if (submitBtn) {
-                submitBtn.hidden = step !== totalSteps;
+                const showSubmit = step === totalSteps;
+                submitBtn.hidden = !showSubmit;
+                submitBtn.disabled = !showSubmit;
             }
         }
 
@@ -481,6 +483,28 @@
             const allChecked = Array.from(checkboxes).every((cb) => cb.checked);
             checkboxes.forEach((cb) => {
                 cb.checked = !allChecked;
+            });
+        });
+
+        const shuffleForm = document.getElementById('shuffle-wizard-form');
+        shuffleForm?.addEventListener('keydown', (e) => {
+            if (e.key !== 'Enter') {
+                return;
+            }
+            const t = e.target;
+            if (t && t.matches && t.matches('input[type="checkbox"]')) {
+                e.preventDefault();
+            }
+        });
+        shuffleForm?.addEventListener('submit', (e) => {
+            if (submitBtn && submitBtn.disabled) {
+                e.preventDefault();
+            }
+        });
+
+        shuffleDialog?.addEventListener('close', () => {
+            window.requestAnimationFrame(() => {
+                document.body.getBoundingClientRect();
             });
         });
 


### PR DESCRIPTION
## Cause
- Implicit HTML form submission (**Enter**) can still target the lone `type=submit` even when it is only `hidden`, which matches “last row” / keyboard flows and closes/navigates oddly.
- `::backdrop` + `backdrop-filter` can leave a blurred layer after `close()` in some engines.

## Fix
- `#shuffle-submit` is `disabled` unless step 3 is active (in addition to `hidden`).
- `keydown` Enter on checkboxes: `preventDefault`.
- `submit` guard if button disabled.
- `#shuffle-modal::backdrop`: solid dim only, no blur.
- Scroll: `overscroll-behavior: contain`, safe-area padding-bottom.
- `close` listener forces a reflow (cheap repaint helper).

## Testing
`npm run build`, `php artisan test`.

Made with [Cursor](https://cursor.com)