### PR TITLE
fix: change effects and playstyle columns from varchar to text

### DIFF
--- a/database/migrations/2026_04_11_003807_change_effects_playstyle_to_text_in_decks_table.php
+++ b/database/migrations/2026_04_11_003807_change_effects_playstyle_to_text_in_decks_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Change effects and playstyle from varchar(191) to text.
+     *
+     * The original migration defined these as string() (varchar) but they were later
+     * corrected to text() in the schema file. Existing databases that ran the original
+     * migration need this ALTER TABLE to match.
+     */
+    public function up(): void
+    {
+        Schema::table('decks', function (Blueprint $table) {
+            $table->text('effects')->nullable()->change();
+            $table->text('playstyle')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('decks', function (Blueprint $table) {
+            $table->string('effects')->nullable()->change();
+            $table->string('playstyle')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- `effects` and `playstyle` columns in the `decks` table were `varchar(191)` in existing databases
- The original migration already says `text()` but was already recorded as run, so edits to it had no effect
- Long faction text (e.g. Sheep effects: ~700 chars) exceeded the 191-byte limit, crashing `factions:import`

## Change

New migration `2026_04_11_003807_change_effects_playstyle_to_text_in_decks_table` alters both columns to `text` on existing databases.

## Test plan

- [ ] `php artisan test` → 85 passed
- [ ] `php artisan factions:enrich --force` → Done. Created: 0, updated: 106, skipped: 0.

Made with [Cursor](https://cursor.com)