### PR TITLE
chore: optimize cursor workflow rule with two-tier system

### DIFF
--- a/.cursor/rules/smash-up-full-workflow.mdc
+++ b/.cursor/rules/smash-up-full-workflow.mdc
@@ -1,45 +1,64 @@
 ---
-description: Full dev workflow for this repo — analyze → ticket → plan → branch → DDEV → implement → tests → lint → browser → docs → commit → push → PR → merge → cleanup. Default for code/feature work unless the user opts out.
+description: Full dev workflow for this repo — analyze → ticket → plan → branch → implement → tests → lint → browser → docs → commit → push → PR → merge → cleanup. Default for code/feature work unless the user opts out.
 alwaysApply: true
 ---
 
 ## Scope
 
 - Applies to **every user request related to code or features** in this repository **by default**.
-- **Opt-out** examples: "nur Erklärung, kein Code", "skip workflow", "kein Workflow jetzt", "nicht automatisch committen/pushen", "nur quick fix ohne workflow", "kein Merge / PR offen lassen".
+- **Opt-out** examples: "skip workflow" / "kein Workflow", "quick fix" / "nur quick fix", "no merge" / "kein Merge", "nur Erklärung, kein Code", "suggestion only".
 - If intent is ambiguous, ask **one concise message** with all open questions before deviating from the sequence.
 
 ### First response (when starting work on a change)
 
-State that the **Smash Up full workflow** is being followed, for example:
+State the track being followed:
 
-> Ich folge dem vollständigen Projekt-Workflow. Phasen: Analyse (inkl. **`docs/roadmap.md`**-Scan und bei Bedarf **öffentliche Copy**/Lang-Dateien) → Ticket → Plan → Branch → DDEV → Implementierung → Tests → Lint → Browser → Docs (Roadmap + CHANGELOG + ggf. **EN/DE Lang**) → Commit → Push → PR → Merge.
+> **Full workflow:** Analyze (roadmap scan + public copy check) → Ticket → Plan → Branch → Implement → Tests → Lint → Browser → Docs → Commit → Push → PR → Merge → Cleanup.
 
-(English is fine if the session is English-only.)
+> **Quick track:** Branch → Implement → Lint → Commit → Push → PR → Merge.
 
 ---
 
-## Hard stop — before ANY code change
+## Two-tier system
 
-**Do not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` (install/build/migrate that changes project artifacts) before completing:
+### Full track (default for non-trivial work)
+
+All phases apply. Use when **any** of the following is true:
+- New DB migration
+- New public route or controller
+- More than 5 files changed
+- New external dependency
+- UX-visible change affecting guests
+
+### Quick track (opt-in for small fixes)
+
+**Phases skipped:** Ticket file, Plan mode, roadmap scan.  
+**Trigger:** user says "quick fix" / "nur quick fix" / "kleine Korrektur" **or** the change clearly touches ≤ 3 files with no migration, no new route, no UX impact.  
+**Phases still required:** Branch → Implement → Lint → Commit → Push → PR → Merge.
+
+---
+
+## Hard stop — before ANY code change (Full track only)
+
+**Do not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` before completing:
 
 ```
 [ ] Phase 1 — Analyze: codebase explored, affected files/patterns identified
-[ ] Phase 2 — Ticket: `docs/tickets/YYYY-MM-DD-short-slug.md` written (see `ticket-authoring.mdc`) + optional IssueForge POST if configured (see Phase 2)
-[ ] Phase 3 — Plan: for non-trivial work — `SwitchMode(plan)` + `CreatePlan` tool; user confirmed when required
-[ ] Phase 4 — Branch: feature/fix branch created from latest `dev` (or user-approved base)
+[ ] Phase 2 — Ticket: `docs/tickets/YYYY-MM-DD-short-slug.md` written (see `ticket-authoring.mdc`)
+[ ] Phase 3 — Plan: criteria met → `SwitchMode(plan)` + `CreatePlan`; user confirmed
+[ ] Phase 4 — Branch: feature/fix branch created from latest `dev`
 ```
 
-If any box is unchecked, complete that phase first. **Inline markdown plans are not a substitute** for Cursor Plan mode + `CreatePlan` where this rule requires it.
+**Inline markdown plans are not a substitute** for Cursor Plan mode + `CreatePlan` where Phase 3 applies.
 
 ---
 
 ## Recovery protocol (phases were skipped)
 
 1. **Stop** further code changes until recovery is in order.
-2. **Backfill** in order: ticket file (+ optional IssueForge) → plan (Plan mode + `CreatePlan` if applicable) → branch (`git stash` → checkout `dev` → pull → branch → `git stash pop` if needed).
+2. **Backfill** in order: ticket file → plan (if applicable) → branch (`git stash` → checkout `dev` → pull → branch → `git stash pop`).
 3. **Acknowledge** which phase was skipped and that it is being remediated.
-4. Continue with tests, lint, docs, commit, push, PR, **merge**, **cleanup** — unless the user opted out of merge.
+4. Continue with lint, docs, commit, push, PR, **merge**, **cleanup** — unless the user opted out.
 
 ---
 
@@ -64,32 +83,41 @@ Do not implement while blocking questions are unanswered.
 3. Reuse existing patterns: thin controllers, Form Requests where appropriate, Eloquent, Blade components, Vite entrypoints, bilingual `__('frontend.key')` / `__('backend.key')`.
 4. **Output:** mental model of affected files, risks, test surfaces.
 
-5. **Roadmap scan (mandatory):** Read **`docs/roadmap.md`** (at least Vision, Shipped, Now, Next, First release readiness if present). If this change **implements, completes, or materially advances** any bullet, table row, or checklist line, plan a **`docs/roadmap.md` edit in the same PR** (Phase 6c), unless the ticket **explicitly** defers roadmap updates **and** the user agreed.
+5. **Roadmap scan:** Read **`docs/roadmap.md`** **only when** classification = `feature` or the chore explicitly maps to a roadmap bullet. If this change **implements, completes, or materially advances** any item, plan a **`docs/roadmap.md` edit in the same PR** (Phase 8). For bugfixes restoring documented behavior: **Roadmap: N/A** — no scan required.
 
-6. **Public-facing copy / “what visitors notice” (when applicable):** This project does **not** use `whatsNew.ts`. When a change materially affects **guest-visible** UI, landing/legal trust, or headline flows, plan updates in the **same PR** to:
+6. **Public-facing copy (when applicable):** When a change materially affects **guest-visible** UI, landing/legal trust, or headline flows, plan updates in the **same PR** to:
    - **`CHANGELOG.md`** `[Unreleased]` (user-visible notes), and
-   - relevant **`resources/lang/en/`** and **`resources/lang/de/`** (and `lang/` if used) for new/changed strings.
-   If the change is **internal-only** or **invisible to users**, state **Public copy: N/A** with one line.
+   - relevant **`resources/lang/en/`** and **`resources/lang/de/`** for new/changed strings.
+   If the change is **internal-only** or **invisible to users**, state **Public copy: N/A**.
 
 ---
 
-## Phase 2 — Ticket (Markdown + optional IssueForge)
+## Phase 2 — Ticket (Full track only)
 
 Follow **`ticket-authoring.mdc`**.
 
 - `Write` the ticket to `docs/tickets/YYYY-MM-DD-short-slug.md` (content matches chat).
-- **IssueForge (optional):** Only if `.env` defines `ISSUE_FORGE_BASE_URL`, `ISSUE_FORGE_PROJECT_ID`, and `API_ADMIN_TOKEN` (or the variables your integration expects). Then `POST` to `$ISSUE_FORGE_BASE_URL/tickets` with JSON including `project_id`, `title`, `description`, `status: "open"`, `priority`. On **201**, report id. On missing env or failure: note **IssueForge: skipped**; do not block the rest.
+- **IssueForge (optional):** Only if `.env` defines `ISSUE_FORGE_BASE_URL`, `ISSUE_FORGE_PROJECT_ID`, and `API_ADMIN_TOKEN`. Then `POST` with `project_id`, `title`, `description`, `status: "open"`, `priority`. On **201**, report id. On missing env or failure: note **IssueForge: skipped**.
 
 ---
 
-## Phase 3 — Plan
+## Phase 3 — Plan (Full track only)
 
-- **Non-trivial** changes (new features, multi-file, refactors with trade-offs): use Cursor **Plan mode**: `SwitchMode(plan)`, then **`CreatePlan`** — not a substitute plan pasted in chat.
-- Wait for **explicit user confirmation** when Plan mode requires it, then return to Agent mode.
+Use Cursor **Plan mode** when **any** of the following applies:
+- New DB migration
+- New public route or controller
+- More than 5 files changed
+- New external dependency
+- Architectural trade-offs with no clear winner
+
+`SwitchMode(plan)` → `CreatePlan` — never substitute with an inline markdown plan.  
+Wait for **explicit user confirmation**, then return to Agent mode.
+
+For changes that meet Full track criteria but **none** of the Plan mode triggers above: skip Plan mode, document reasoning briefly, proceed to Phase 4.
 
 ---
 
-## Phase 4 — Branch (GitHub; base `dev`)
+## Phase 4 — Branch (base `dev`)
 
 ```bash
 git checkout dev && git pull origin dev
@@ -100,76 +128,62 @@ If `dev` is missing, **ask** whether to use `main` or another base.
 
 ---
 
-## Phase 5 — DDEV
+## Phase 5 — Implement
 
-- This project uses **DDEV** (see `README.md`). Prefer `ddev start` before `php artisan` / Composer / npm inside the stack.
-- Typical patterns: `ddev exec php artisan …`, `ddev composer …`, `ddev npm run …`.
-- If DDEV cannot be run in the environment, list exact commands for the user’s machine.
-
----
-
-## Phase 6 — Implement
-
-- **Laravel:** thin controllers, Form Requests, policies/middleware as needed, Eloquent, strict types, PSR-12, DocBlocks per README Style Guide / team PHP conventions.
-- **Frontend:** Blade + Vite; **vanilla JS** (and Alpine as already used); avoid duplicating API logic — keep scripts in `resources/js/` with clear modules.
+- **Before running artisan / Composer / npm:** use `ddev exec …` / `ddev composer …` / `ddev npm run …` (project uses DDEV; see `README.md`). If DDEV cannot be run, list exact commands for the user's machine.
+- **Laravel:** thin controllers, Form Requests, policies/middleware as needed, Eloquent, strict types, PSR-12, DocBlocks.
+- **Frontend:** Blade + Vite; **vanilla JS** (and Alpine as already used); keep scripts in `resources/js/`.
 - **No** mock/fake data in dev or prod paths (tests only).
-- After migrations in dev: `php artisan migrate` (via DDEV as appropriate).
+- After migrations in dev: `ddev exec php artisan migrate`.
 - Keep files roughly under 200–300 lines; extract services when justified.
-- **GDPR:** do not add tracking/analytics cookies or third-party trackers without explicit product decision and legal review.
+- **GDPR:** no tracking/analytics without explicit product decision and legal review.
 
 ---
 
-## Phase 6b — Tests (author + run)
+## Phase 6 — Tests
 
-- **PHPUnit:** `tests/Feature`, `tests/Unit`; factories/mocks; no real external services in tests.
-- **Run** relevant tests via Shell, e.g. `ddev exec php artisan test` or `php artisan test`. Do not only author tests.
+- **PHPUnit:** `tests/Feature`, `tests/Unit`; factories/mocks; no real external services.
+- **Run** tests: `ddev exec php artisan test`. Do not only author tests — run them.
 
 ---
 
-## Phase 6c — Documentation & changelog
+## Phase 7 — Lint & static analysis
+
+- **PHP:** PSR-12; run `./vendor/bin/pint --test` if Pint is installed (`composer.json`).
+- **JS:** consistent with existing files; run ESLint only if the project already uses it.
+- **`ReadLints`** on all changed files before commit.
+
+---
+
+## Phase 8 — Docs & changelog
 
 - Update **`README.md`** / **`docs/`** when behavior or onboarding changes.
 - **`CHANGELOG.md`:** add under `[Unreleased]` when the change is user-visible or operationally notable.
 
 ### `docs/roadmap.md`
 
-- If Phase 1 matched roadmap scope, **update `docs/roadmap.md` in the same PR**: move completed items toward **Shipped**, adjust **Now** / **Next**, keep sections accurate.
+Update **only if** Phase 1 triggered a roadmap scan and found a match: move completed items toward **Shipped**, adjust **Now** / **Next**.
 
-### Roadmap N/A (allowed only when true)
-
-- Internal refactor with **no** roadmap bullet touched; bugfix restoring documented behavior; dependency bump with no product story in roadmap.
-
-**Invalid:** “docs only” / “small chore” if **Now** / **Next** explicitly lists that work.
-
-### Public copy N/A (visitor-notable work)
-
-- If the PR changes public routes, major Blade flows, or legal/privacy copy, prefer **not** to skip Lang + CHANGELOG unless you document **Public copy: N/A** with a valid reason (e.g. typo fix in admin-only view).
+**Valid Roadmap: N/A:** bugfix restoring documented behavior; internal refactor not listed in Now/Next; dependency bump with no product story.  
+**Invalid:** "docs only" / "small chore" if **Now** / **Next** explicitly lists that work.
 
 ---
 
-## Phase 7 — Lint & static analysis
-
-- **PHP:** PSR-12; run project tools if added later (Pint/PHPStan) per `composer.json` / CI.
-- **JS:** sensible formatting consistent with existing files; add ESLint only if the project already uses it.
-- **`ReadLints`** on changed files before commit.
-
----
-
-## Phase 8 — Browser / manual verification
+## Phase 9 — Browser / manual verification
 
 - **UI changes:** use Cursor browser MCP when available; otherwise concrete steps aligned with ticket **Requirements** (include EN/DE if both are affected).
 - **Backend-only / CLI-only:** state **no browser test required** and rely on automated tests.
 
 ---
 
-## Phase 9 — Commit
+## Phase 10 — Commit
 
 **Pre-commit gate:**
 
 ```
-[ ] Phase 6c satisfied (README/docs/CHANGELOG as needed)
-[ ] Roadmap: `docs/roadmap.md` updated if Phase 1 matched — or valid **Roadmap: N/A**
-[ ] Public copy: Lang + CHANGELOG touched if visitor-notable — or valid **Public copy: N/A**
+[ ] Phase 8 satisfied (README/docs/CHANGELOG as needed)
+[ ] Roadmap: `docs/roadmap.md` updated if scan matched — or valid Roadmap: N/A
+[ ] Public copy: Lang + CHANGELOG touched if visitor-notable — or valid Public copy: N/A
 ```
 
 - Use **`TodoWrite`** for full workflow runs; do not leave stale `in_progress`.
@@ -178,7 +192,7 @@ If `dev` is missing, **ask** whether to use `main` or another base.
 
 ---
 
-## Phase 10 — Push
+## Phase 11 — Push
 
 ```bash
 git push -u origin <branch-name>
@@ -186,24 +200,23 @@ git push -u origin <branch-name>
 
 ---
 
-## Phase 11 — Pull request (GitHub)
+## Phase 12 — Pull request (GitHub)
 
 - Target **`dev`** unless opted out or another base is agreed.
-- PR body should note **Roadmap** (updated vs N/A) and **Public copy** (CHANGELOG/Lang vs N/A).
-
-Prefer **`gh pr create`** when available; otherwise web UI.
+- PR body: note **Roadmap** (updated vs N/A) and **Public copy** (CHANGELOG/Lang vs N/A).
+- Prefer **`gh pr create`** when available.
 
 ---
 
-## Phase 12 — Merge (GitHub)
+## Phase 13 — Merge (GitHub)
 
-- After PR creation, **attempt merge in the same workflow** when GitHub allows and checks pass, unless the user opted out of merge.
+- After PR creation, **attempt merge in the same workflow** when GitHub allows and checks pass, unless the user opted out.
 - Prefer: `gh pr merge <number> --squash --delete-branch`
 - Do **not** merge if required checks failed unless the user explicitly overrides.
 
 ---
 
-## Phase 13 — Post-merge cleanup
+## Phase 14 — Post-merge cleanup
 
 - `git checkout dev && git pull origin dev`
 - Delete local feature branch; remote often removed by `--delete-branch`.
@@ -212,30 +225,23 @@ Prefer **`gh pr create`** when available; otherwise web UI.
 
 ## Violations — NEVER
 
-- Substitute `CreatePlan` with a long inline plan when Plan mode is required.
-- Skip the ticket file on disk for work that warrants a ticket.
-- Commit without running relevant tests + `ReadLints` where applicable.
-- Finish full workflow after push + PR **without attempting merge** when mergeable (unless opted out).
-- Ship roadmap-tracked work **without** updating **`docs/roadmap.md`** (unless deferred in ticket + user agreed).
-- Skip Phase 1 roadmap scan or use a fake **Roadmap: N/A**.
+- Skip the ticket file (Full track) or use an inline plan instead of `CreatePlan` (when Plan mode applies).
+- Commit without running tests + `ReadLints`.
+- Finish after push + PR without attempting merge (unless opted out).
+- Ship roadmap-tracked work without updating `docs/roadmap.md` (unless deferred in ticket + user agreed).
 
 ---
 
-## Ordering (strict)
+## Ordering
 
-Analyze (roadmap + public-copy check) → ticket → plan (if required) → branch → DDEV → implement → tests → lint → browser → docs/changelog/roadmap/lang → gates → commit → push → PR → merge → cleanup.
+**Full track:** Analyze → Ticket → Plan (if triggered) → Branch → Implement → Tests → Lint → Docs → Browser → Commit → Push → PR → Merge → Cleanup.
 
----
-
-## Opting out
-
-- Examples: no commit/push; suggestion-only; ticket only; **kein Merge**.
-- State clearly which steps were skipped.
+**Quick track:** Branch → Implement → Lint → Commit → Push → PR → Merge → Cleanup.
 
 ---
 
 ## Project-specific stack (reminder)
 
-- Laravel 13, **PHP 8.3+** (`composer.json`), **MariaDB 10.4 in DDEV** (MySQL-compatible in prod is fine), Blade, Sanctum & Passport (OAuth tables), **Vite 5**, **Tailwind CSS 4** (`@tailwindcss/vite`), jQuery/Alpine as in `package.json` (Node **20+** for frontend builds).
-- Bilingual: maintain **EN and DE** when changing user-facing strings (`resources/lang/`, `lang/`).
-- **Canonical onboarding:** `README.md` (DDEV hostname: `name` in `.ddev/config.yaml`, currently `smash-up-randomizer.ddev.site`).
+- Laravel 13, **PHP 8.3+**, **MariaDB 10.4 in DDEV**, Blade, Sanctum & Passport, **Vite 5**, **Tailwind CSS 4** (`@tailwindcss/vite`), jQuery/Alpine (Node **20+**).
+- Bilingual: maintain **EN and DE** for user-facing strings (`resources/lang/`, `lang/`).
+- **Canonical onboarding:** `README.md` (DDEV hostname: `smash-up-randomizer.ddev.site`).

--- a/docs/tickets/2026-04-14-optimize-cursor-workflow-rule.md
+++ b/docs/tickets/2026-04-14-optimize-cursor-workflow-rule.md
@@ -1,0 +1,29 @@
+## Optimize Cursor implementation workflow rule
+
+## Summary
+Refactor `smash-up-full-workflow.mdc` to reduce unnecessary friction for small changes while keeping full governance for non-trivial work. Introduces a two-tier system, cleaner phase numbering, and sharper criteria throughout.
+
+## Background / Context
+- Current behavior: every code change — from a typo fix to a new feature — triggers the identical 13-phase workflow including mandatory ticket, Plan mode, and roadmap scan.
+- This creates real friction for small bug fixes and makes the rule feel heavy, leading to implicit skipping rather than explicit opt-out.
+- No external designs or prior tickets; improvements identified via workflow review session.
+
+## Requirements
+- [x] Introduce explicit Quick Track (≤ 3 files, no migration, no UX impact) skipping ticket + Plan mode
+- [x] Define concrete Plan mode trigger criteria (new route/controller, migration, > 5 files, new dependency)
+- [x] Remove Phase 5 (DDEV) as standalone phase; inline DDEV note into Phase 6
+- [x] Renumber phases cleanly: 6/6b/6c → sequential integers
+- [x] Conditionalise roadmap scan: only for features and roadmap-adjacent chores; auto N/A for bugfixes
+- [x] Shorten "Violations — NEVER" section (remove pure duplicates)
+- [x] Make opt-out examples bilingual (EN + DE)
+
+## Technical notes
+- Affected file: `.cursor/rules/smash-up-full-workflow.mdc`
+- No code changes; no migration; no lang files.
+
+## Testing
+- **Manual:** trigger a Quick Track change and verify AI follows lightweight path; trigger a full feature and verify all gates still apply.
+
+## Impact / Risks
+- AI behaviour governed by this rule changes immediately on merge to `dev`.
+- Rollback: revert the file; no side effects.


### PR DESCRIPTION
## Summary
- Introduces Quick track for small fixes (≤3 files, no migration/UX) — skips ticket + Plan mode
- Defines concrete Plan mode trigger criteria instead of vague "non-trivial"
- Removes Phase 5 (DDEV) as standalone phase; inlined into Implement
- Renumbers phases sequentially (was 6/6b/6c sprawl, now clean 1–14)
- Conditionalises roadmap scan: features only, auto N/A for bugfixes
- Trims Violations section (no more duplicate content)
- Opt-out examples now bilingual (EN + DE)

## Roadmap
N/A — internal tooling change, no roadmap bullet.

## Public copy
N/A — no user-visible strings changed.

Made with [Cursor](https://cursor.com)