### PR TITLE
feat: add quick shuffle link to landing page hero

### DIFF
--- a/resources/lang/en/frontend.php
+++ b/resources/lang/en/frontend.php
@@ -243,5 +243,6 @@ return [
     'factions_browse_by_set' => 'Browse by expansion',
 
     // Quick shuffle
-    'random_page_title' => 'Quick Shuffle',
+    'random_page_title'  => 'Quick Shuffle',
+    'landing_cta_random' => 'Quick shuffle (2 players, instant)',
 ];

--- a/resources/views/start/home.blade.php
+++ b/resources/views/start/home.blade.php
@@ -21,7 +21,11 @@
                         <a href="{{ route('factionList') }}" class="sur-btn-secondary min-h-12 px-8 text-base">{{ __('frontend.landing_cta_factions') }}</a>
                         <a href="{{ route('contact') }}" class="sur-btn-ghost min-h-12 border-white/15 px-8 text-base">{{ __('frontend.landing_cta_contact') }}</a>
                     </div>
-                    <p class="mt-5 max-w-xl text-sm leading-relaxed text-zinc-500">
+                    <a href="{{ route('random') }}" class="mt-3 inline-flex items-center gap-1.5 text-sm text-zinc-500 transition hover:text-indigo-400">
+                        <i class="fa-solid fa-bolt text-xs" aria-hidden="true"></i>
+                        {{ __('frontend.landing_cta_random') }}
+                    </a>
+                    <p class="mt-4 max-w-xl text-sm leading-relaxed text-zinc-500">
                         {{ __('frontend.landing_hero_note') }}
                     </p>
                 </div>


### PR DESCRIPTION
Adds a subtle text-link below the main CTA buttons pointing to `/random` — gives users a one-click path to instant shuffle without the wizard.

**Roadmap:** N/A
**Public copy:** N/A (new lang key, minor copy addition)

Made with [Cursor](https://cursor.com)