### PR TITLE
fix: expansion card text always below thumbnail

### DIFF
--- a/resources/views/expansions/index.blade.php
+++ b/resources/views/expansions/index.blade.php
@@ -62,7 +62,7 @@
                     </div>
 
                     {{-- Info --}}
-                    <div class="flex flex-1 items-center justify-between gap-3 p-4">
+                    <div class="flex items-start justify-between gap-3 p-4">
                         <div>
                             <h2 class="text-sm font-bold leading-tight text-white transition group-hover:text-indigo-300">
                                 {{ $expansion['name'] }}


### PR DESCRIPTION
items-center centered text vertically in remaining card space — with 2 images it floated mid-card. items-start pins it directly below the thumbnail.

Made with [Cursor](https://cursor.com)