### PR TITLE
refactor: move profile/password forms to /account/edit subpage

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -19,6 +19,13 @@ class AccountController extends Controller
         ]);
     }
 
+    public function edit(Request $request): View
+    {
+        return view('account.edit', [
+            'user' => $request->user(),
+        ]);
+    }
+
     public function updateProfile(Request $request): RedirectResponse
     {
         $user = $request->user();
@@ -45,7 +52,7 @@ class AccountController extends Controller
                 ->with('status', __('frontend.account_profile_email_changed'));
         }
 
-        return redirect()->route('account')->with('profile_status', __('frontend.account_profile_saved'));
+        return redirect()->route('account.edit')->with('profile_status', __('frontend.account_profile_saved'));
     }
 
     public function updatePassword(Request $request): RedirectResponse
@@ -58,7 +65,7 @@ class AccountController extends Controller
         $user = $request->user();
 
         if (! Hash::check($request->current_password, $user->password)) {
-            return redirect()->route('account')->withErrors(
+            return redirect()->route('account.edit')->withErrors(
                 ['current_password' => __('frontend.account_password_wrong_current')],
                 'passwordErrors'
             );
@@ -66,6 +73,6 @@ class AccountController extends Controller
 
         $user->update(['password' => Hash::make($request->password)]);
 
-        return redirect()->route('account')->with('password_status', __('frontend.account_password_saved'));
+        return redirect()->route('account.edit')->with('password_status', __('frontend.account_password_saved'));
     }
 }

--- a/resources/lang/de/frontend.php
+++ b/resources/lang/de/frontend.php
@@ -294,6 +294,12 @@ return [
     'account_feat_history_body'    => 'Durchstöbere vergangene Shuffle-Ergebnisse und sieh, welche Fraktionskombinationen deine Gruppe gespielt hat.',
     'account_quick_actions'        => 'Schnellzugriff',
 
+    // Account — Bearbeitungsseite
+    'account_edit_page_heading'         => 'Account bearbeiten',
+    'account_edit_page_sub'             => 'Ändere deinen Anzeigenamen, deine E-Mail-Adresse und dein Passwort.',
+    'account_edit_back'                 => 'Zurück zum Account',
+    'account_edit_link'                 => 'Account bearbeiten',
+
     // Account — Profil bearbeiten
     'account_edit_profile_heading'      => 'Profil bearbeiten',
     'account_edit_profile_name'         => 'Anzeigename',

--- a/resources/lang/en/frontend.php
+++ b/resources/lang/en/frontend.php
@@ -312,6 +312,12 @@ return [
     'account_feat_history_body'    => 'Browse past shuffle results and see which faction combos your group has played.',
     'account_quick_actions'        => 'Quick actions',
 
+    // Account — edit page
+    'account_edit_page_heading'         => 'Edit account',
+    'account_edit_page_sub'             => 'Update your display name, e-mail address, and password.',
+    'account_edit_back'                 => 'Back to account',
+    'account_edit_link'                 => 'Edit account',
+
     // Account — edit profile
     'account_edit_profile_heading'      => 'Edit profile',
     'account_edit_profile_name'         => 'Display name',

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -1,0 +1,175 @@
+<x-layouts.main>
+
+    <div class="relative min-h-screen bg-zinc-950 pt-14" style="padding-bottom: 10rem">
+        <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-5%,rgb(99_102_241_/_0.18),transparent)]" aria-hidden="true"></div>
+        <div class="pointer-events-none absolute inset-0 opacity-[0.025] [background-image:linear-gradient(to_right,#fff_1px,transparent_1px),linear-gradient(to_bottom,#fff_1px,transparent_1px)] [background-size:40px_40px]" aria-hidden="true"></div>
+
+        <x-sur.container class="relative">
+
+            {{-- Back link + page heading --}}
+            <x-sur.reveal>
+                <div class="mb-8">
+                    <a href="{{ route('account') }}" class="mb-6 inline-flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-300">
+                        <i class="fa-solid fa-arrow-left text-xs" aria-hidden="true"></i>
+                        {{ __('frontend.account_edit_back') }}
+                    </a>
+                    <h1 class="text-2xl font-semibold text-white">{{ __('frontend.account_edit_page_heading') }}</h1>
+                    <p class="mt-1 text-sm text-zinc-500">{{ __('frontend.account_edit_page_sub') }}</p>
+                </div>
+            </x-sur.reveal>
+
+            <div class="mx-auto max-w-2xl space-y-6">
+
+                {{-- Edit profile --}}
+                <x-sur.reveal>
+                    <div class="rounded-2xl border border-white/10 bg-white/[0.04] shadow-lg shadow-black/20 backdrop-blur-sm">
+                        <div class="border-b border-white/8 px-8 py-6">
+                            <h2 class="text-base font-semibold text-white">{{ __('frontend.account_edit_profile_heading') }}</h2>
+                        </div>
+
+                        @if(session('profile_status'))
+                            <div class="mx-8 mt-6 flex items-center gap-2.5 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-400">
+                                <i class="fa-solid fa-circle-check shrink-0" aria-hidden="true"></i>
+                                {{ session('profile_status') }}
+                            </div>
+                        @endif
+
+                        <form method="POST" action="{{ route('account.profile.update') }}" class="px-8 py-6" novalidate>
+                            @csrf
+                            @method('PATCH')
+
+                            <div class="space-y-5">
+                                <div>
+                                    <label for="name" class="mb-1.5 block text-xs font-semibold text-zinc-400">
+                                        {{ __('frontend.account_edit_profile_name') }}
+                                    </label>
+                                    <input
+                                        id="name"
+                                        type="text"
+                                        name="name"
+                                        value="{{ old('name', $user->name) }}"
+                                        required
+                                        autocomplete="name"
+                                        class="w-full rounded-xl border px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:ring-2
+                                            {{ $errors->has('name') ? 'border-red-500/60 bg-red-500/5 focus:ring-red-500/30' : 'border-white/10 bg-white/[0.04] focus:border-indigo-500/60 focus:ring-indigo-500/20' }}"
+                                    >
+                                    @error('name')
+                                        <p class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
+                                    @enderror
+                                </div>
+
+                                <div>
+                                    <label for="email" class="mb-1.5 block text-xs font-semibold text-zinc-400">
+                                        {{ __('frontend.account_edit_profile_email') }}
+                                    </label>
+                                    <input
+                                        id="email"
+                                        type="email"
+                                        name="email"
+                                        value="{{ old('email', $user->email) }}"
+                                        required
+                                        autocomplete="email"
+                                        class="w-full rounded-xl border px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:ring-2
+                                            {{ $errors->has('email') ? 'border-red-500/60 bg-red-500/5 focus:ring-red-500/30' : 'border-white/10 bg-white/[0.04] focus:border-indigo-500/60 focus:ring-indigo-500/20' }}"
+                                    >
+                                    @error('email')
+                                        <p class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="mt-6 flex justify-end">
+                                <button type="submit" class="sur-btn-primary inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium">
+                                    <i class="fa-solid fa-floppy-disk text-xs" aria-hidden="true"></i>
+                                    {{ __('frontend.account_edit_profile_save') }}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </x-sur.reveal>
+
+                {{-- Change password --}}
+                <x-sur.reveal>
+                    <div class="rounded-2xl border border-white/10 bg-white/[0.04] shadow-lg shadow-black/20 backdrop-blur-sm">
+                        <div class="border-b border-white/8 px-8 py-6">
+                            <h2 class="text-base font-semibold text-white">{{ __('frontend.account_change_password_heading') }}</h2>
+                        </div>
+
+                        @if(session('password_status'))
+                            <div class="mx-8 mt-6 flex items-center gap-2.5 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-400">
+                                <i class="fa-solid fa-circle-check shrink-0" aria-hidden="true"></i>
+                                {{ session('password_status') }}
+                            </div>
+                        @endif
+
+                        <form method="POST" action="{{ route('account.password.update') }}" class="px-8 py-6" novalidate>
+                            @csrf
+                            @method('PATCH')
+
+                            <div class="space-y-5">
+                                <div>
+                                    <label for="current_password" class="mb-1.5 block text-xs font-semibold text-zinc-400">
+                                        {{ __('frontend.account_password_current') }}
+                                    </label>
+                                    <input
+                                        id="current_password"
+                                        type="password"
+                                        name="current_password"
+                                        required
+                                        autocomplete="current-password"
+                                        class="w-full rounded-xl border px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:ring-2
+                                            {{ $errors->passwordErrors->has('current_password') ? 'border-red-500/60 bg-red-500/5 focus:ring-red-500/30' : 'border-white/10 bg-white/[0.04] focus:border-indigo-500/60 focus:ring-indigo-500/20' }}"
+                                    >
+                                    @if($errors->passwordErrors->has('current_password'))
+                                        <p class="mt-1.5 text-xs text-red-400">{{ $errors->passwordErrors->first('current_password') }}</p>
+                                    @endif
+                                </div>
+
+                                <div>
+                                    <label for="password" class="mb-1.5 block text-xs font-semibold text-zinc-400">
+                                        {{ __('frontend.account_password_new') }}
+                                    </label>
+                                    <input
+                                        id="password"
+                                        type="password"
+                                        name="password"
+                                        required
+                                        autocomplete="new-password"
+                                        class="w-full rounded-xl border px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:ring-2
+                                            {{ $errors->passwordErrors->has('password') ? 'border-red-500/60 bg-red-500/5 focus:ring-red-500/30' : 'border-white/10 bg-white/[0.04] focus:border-indigo-500/60 focus:ring-indigo-500/20' }}"
+                                    >
+                                    @if($errors->passwordErrors->has('password'))
+                                        <p class="mt-1.5 text-xs text-red-400">{{ $errors->passwordErrors->first('password') }}</p>
+                                    @endif
+                                </div>
+
+                                <div>
+                                    <label for="password_confirmation" class="mb-1.5 block text-xs font-semibold text-zinc-400">
+                                        {{ __('frontend.account_password_confirm') }}
+                                    </label>
+                                    <input
+                                        id="password_confirmation"
+                                        type="password"
+                                        name="password_confirmation"
+                                        required
+                                        autocomplete="new-password"
+                                        class="w-full rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:border-indigo-500/60 focus:ring-2 focus:ring-indigo-500/20"
+                                    >
+                                </div>
+                            </div>
+
+                            <div class="mt-6 flex justify-end">
+                                <button type="submit" class="sur-btn-primary inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium">
+                                    <i class="fa-solid fa-lock text-xs" aria-hidden="true"></i>
+                                    {{ __('frontend.account_password_save') }}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </x-sur.reveal>
+
+            </div>
+        </x-sur.container>
+    </div>
+
+</x-layouts.main>

--- a/resources/views/account/index.blade.php
+++ b/resources/views/account/index.blade.php
@@ -140,151 +140,19 @@
                 </div>
             </x-sur.reveal>
 
-            {{-- Edit profile --}}
+            {{-- Edit account link --}}
             <x-sur.reveal>
                 <div class="rounded-2xl border border-white/10 bg-white/[0.04] shadow-lg shadow-black/20 backdrop-blur-sm">
                     <div class="border-b border-white/8 px-8 py-6">
-                        <h2 class="text-sm font-semibold text-white">{{ __('frontend.account_edit_profile_heading') }}</h2>
+                        <h2 class="text-sm font-semibold text-white">{{ __('frontend.account_edit_page_heading') }}</h2>
                     </div>
-
-                    @if(session('profile_status'))
-                        <div class="mx-8 mt-6 flex items-center gap-2.5 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-400">
-                            <i class="fa-solid fa-circle-check shrink-0" aria-hidden="true"></i>
-                            {{ session('profile_status') }}
-                        </div>
-                    @endif
-
-                    <form method="POST" action="{{ route('account.profile.update') }}" class="px-8 py-6" novalidate>
-                        @csrf
-                        @method('PATCH')
-
-                        <div class="grid gap-5 sm:grid-cols-2">
-                            <div>
-                                <label for="name" class="mb-1.5 block text-xs font-semibold text-zinc-400">
-                                    {{ __('frontend.account_edit_profile_name') }}
-                                </label>
-                                <input
-                                    id="name"
-                                    type="text"
-                                    name="name"
-                                    value="{{ old('name', $user->name) }}"
-                                    required
-                                    autocomplete="name"
-                                    class="w-full rounded-xl border px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:ring-2
-                                        {{ $errors->has('name') ? 'border-red-500/60 bg-red-500/5 focus:ring-red-500/30' : 'border-white/10 bg-white/[0.04] focus:border-indigo-500/60 focus:ring-indigo-500/20' }}"
-                                >
-                                @error('name')
-                                    <p class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
-                                @enderror
-                            </div>
-
-                            <div>
-                                <label for="email" class="mb-1.5 block text-xs font-semibold text-zinc-400">
-                                    {{ __('frontend.account_edit_profile_email') }}
-                                </label>
-                                <input
-                                    id="email"
-                                    type="email"
-                                    name="email"
-                                    value="{{ old('email', $user->email) }}"
-                                    required
-                                    autocomplete="email"
-                                    class="w-full rounded-xl border px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:ring-2
-                                        {{ $errors->has('email') ? 'border-red-500/60 bg-red-500/5 focus:ring-red-500/30' : 'border-white/10 bg-white/[0.04] focus:border-indigo-500/60 focus:ring-indigo-500/20' }}"
-                                >
-                                @error('email')
-                                    <p class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="mt-6 flex justify-end">
-                            <button type="submit" class="sur-btn-primary inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium">
-                                <i class="fa-solid fa-floppy-disk text-xs" aria-hidden="true"></i>
-                                {{ __('frontend.account_edit_profile_save') }}
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </x-sur.reveal>
-
-            {{-- Change password --}}
-            <x-sur.reveal>
-                <div class="rounded-2xl border border-white/10 bg-white/[0.04] shadow-lg shadow-black/20 backdrop-blur-sm">
-                    <div class="border-b border-white/8 px-8 py-6">
-                        <h2 class="text-sm font-semibold text-white">{{ __('frontend.account_change_password_heading') }}</h2>
+                    <div class="flex items-center justify-between px-8 py-6">
+                        <p class="text-sm text-zinc-500">{{ __('frontend.account_edit_page_sub') }}</p>
+                        <a href="{{ route('account.edit') }}" class="ml-6 inline-flex shrink-0 items-center gap-2 rounded-xl border border-white/10 bg-white/[0.05] px-5 py-2.5 text-sm font-medium text-zinc-300 transition hover:bg-white/[0.08] hover:text-white">
+                            <i class="fa-solid fa-pen text-xs" aria-hidden="true"></i>
+                            {{ __('frontend.account_edit_link') }}
+                        </a>
                     </div>
-
-                    @if(session('password_status'))
-                        <div class="mx-8 mt-6 flex items-center gap-2.5 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-400">
-                            <i class="fa-solid fa-circle-check shrink-0" aria-hidden="true"></i>
-                            {{ session('password_status') }}
-                        </div>
-                    @endif
-
-                    <form method="POST" action="{{ route('account.password.update') }}" class="px-8 py-6" novalidate>
-                        @csrf
-                        @method('PATCH')
-
-                        <div class="grid gap-5 sm:grid-cols-3">
-                            <div>
-                                <label for="current_password" class="mb-1.5 block text-xs font-semibold text-zinc-400">
-                                    {{ __('frontend.account_password_current') }}
-                                </label>
-                                <input
-                                    id="current_password"
-                                    type="password"
-                                    name="current_password"
-                                    required
-                                    autocomplete="current-password"
-                                    class="w-full rounded-xl border px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:ring-2
-                                        {{ $errors->passwordErrors->has('current_password') ? 'border-red-500/60 bg-red-500/5 focus:ring-red-500/30' : 'border-white/10 bg-white/[0.04] focus:border-indigo-500/60 focus:ring-indigo-500/20' }}"
-                                >
-                                @if($errors->passwordErrors->has('current_password'))
-                                    <p class="mt-1.5 text-xs text-red-400">{{ $errors->passwordErrors->first('current_password') }}</p>
-                                @endif
-                            </div>
-
-                            <div>
-                                <label for="password" class="mb-1.5 block text-xs font-semibold text-zinc-400">
-                                    {{ __('frontend.account_password_new') }}
-                                </label>
-                                <input
-                                    id="password"
-                                    type="password"
-                                    name="password"
-                                    required
-                                    autocomplete="new-password"
-                                    class="w-full rounded-xl border px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:ring-2
-                                        {{ $errors->passwordErrors->has('password') ? 'border-red-500/60 bg-red-500/5 focus:ring-red-500/30' : 'border-white/10 bg-white/[0.04] focus:border-indigo-500/60 focus:ring-indigo-500/20' }}"
-                                >
-                                @if($errors->passwordErrors->has('password'))
-                                    <p class="mt-1.5 text-xs text-red-400">{{ $errors->passwordErrors->first('password') }}</p>
-                                @endif
-                            </div>
-
-                            <div>
-                                <label for="password_confirmation" class="mb-1.5 block text-xs font-semibold text-zinc-400">
-                                    {{ __('frontend.account_password_confirm') }}
-                                </label>
-                                <input
-                                    id="password_confirmation"
-                                    type="password"
-                                    name="password_confirmation"
-                                    required
-                                    autocomplete="new-password"
-                                    class="w-full rounded-xl border px-4 py-3 text-sm text-white placeholder-zinc-600 outline-none transition focus:ring-2 border-white/10 bg-white/[0.04] focus:border-indigo-500/60 focus:ring-indigo-500/20"
-                                >
-                            </div>
-                        </div>
-
-                        <div class="mt-6 flex justify-end">
-                            <button type="submit" class="sur-btn-primary inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium">
-                                <i class="fa-solid fa-lock text-xs" aria-hidden="true"></i>
-                                {{ __('frontend.account_password_save') }}
-                            </button>
-                        </div>
-                    </form>
                 </div>
             </x-sur.reveal>
 

--- a/routes/frontend-auth.php
+++ b/routes/frontend-auth.php
@@ -54,6 +54,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/account', [AccountController::class, 'index'])
         ->name('account');
 
+    Route::get('/account/edit', [AccountController::class, 'edit'])
+        ->name('account.edit');
+
     Route::patch('/account/profile', [AccountController::class, 'updateProfile'])
         ->name('account.profile.update');
 

--- a/tests/Feature/Account/AccountPasswordUpdateTest.php
+++ b/tests/Feature/Account/AccountPasswordUpdateTest.php
@@ -33,7 +33,7 @@ class AccountPasswordUpdateTest extends TestCase
             'current_password'      => 'current-password',
             'password'              => 'new-password-123',
             'password_confirmation' => 'new-password-123',
-        ])->assertRedirect(route('account'));
+        ])->assertRedirect(route('account.edit'));
 
         $user->refresh();
         $this->assertTrue(Hash::check('new-password-123', $user->password));

--- a/tests/Feature/Account/AccountProfileUpdateTest.php
+++ b/tests/Feature/Account/AccountProfileUpdateTest.php
@@ -122,7 +122,7 @@ class AccountProfileUpdateTest extends TestCase
         $this->patch('/account/profile', [
             'name'  => 'New Name',
             'email' => $user->email,
-        ])->assertRedirect(route('account'));
+        ])->assertRedirect(route('account.edit'));
     }
 
     public function test_unauthenticated_user_is_redirected(): void


### PR DESCRIPTION
## Summary
- Removes the inline edit forms that cluttered the account overview page
- Adds a dedicated `/account/edit` page with "Edit profile" and "Change password" forms
- Account index now shows a clean link card ("Edit account" button) instead

## Changes
- `AccountController`: new `edit()` method; success/error redirects now point to `account.edit`
- `routes/frontend-auth.php`: new `GET /account/edit` route
- `resources/views/account/edit.blade.php`: new dedicated edit page (max-w-2xl, back link, two stacked cards)
- `resources/views/account/index.blade.php`: inline forms replaced with single link card
- Lang files: 4 new strings (EN + DE) for edit page heading/sub/back/link
- Tests updated to assert redirects to `account.edit`

## Roadmap / Public copy
N/A

Made with [Cursor](https://cursor.com)