### PR TITLE
feat: account collection, shuffle presets, play history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
+- **Account: collection, shuffle presets, play history:** Authenticated users can save **owned expansion sets** (`/account/collection`), manage **shuffle presets** (`/account/presets`) and open the home shuffle with one click (`/?shuffle_preset=id`), and browse **recent shuffles** (`/account/history`). When at least one expansion is saved, the shuffle wizard, `POST /shuffle/result`, and `/random` only draw from factions in those sets (guests and users with an empty selection still use all factions). New tables: `user_expansions`, `shuffle_presets`, `shuffle_histories`.
+
 - **Two-factor authentication (TOTP):** Optional MFA for frontend accounts — after password or OAuth sign-in, users with MFA enabled must enter a 6-digit authenticator code or a one-time recovery code. Enable/disable and recovery-code regeneration from **Account → Edit account**. New Composer dependencies: `pragmarx/google2fa`, `pragmarx/google2fa-qrcode`, `bacon/bacon-qr-code`. New columns on `users`: `two_factor_secret`, `two_factor_recovery_codes`, `two_factor_confirmed_at`.
 
 - **Brand assets:** `public/images/brand/logo-mark.png` (512×512 PNG from `logo-mark.svg`); `public/images/brand/logo-mark-oauth.png` same mark on a light gray background for OAuth consoles (GitHub’s dark crop UI).

--- a/app/Http/Controllers/AccountCollectionController.php
+++ b/app/Http/Controllers/AccountCollectionController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Deck;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class AccountCollectionController extends Controller
+{
+    /**
+     * Show expansion checkboxes for the user's owned-sets collection.
+     */
+    public function edit(Request $request): View
+    {
+        $user = $request->user();
+
+        $expansions = Deck::query()
+            ->whereNotNull('expansion')
+            ->where('expansion', '!=', '')
+            ->distinct()
+            ->orderBy('expansion')
+            ->pluck('expansion')
+            ->values();
+
+        $selected = $user->userExpansions()->pluck('expansion')->all();
+
+        return view('account.collection', [
+            'user' => $user,
+            'expansions' => $expansions,
+            'selectedExpansions' => $selected,
+        ]);
+    }
+
+    /**
+     * Replace the user's owned expansion selection.
+     */
+    public function update(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'expansions' => ['nullable', 'array'],
+            'expansions.*' => ['string', 'max:191'],
+        ]);
+
+        $user = $request->user();
+        $user->userExpansions()->delete();
+
+        foreach ($validated['expansions'] ?? [] as $name) {
+            if ($name === '') {
+                continue;
+            }
+            $user->userExpansions()->create(['expansion' => $name]);
+        }
+
+        return redirect()
+            ->route('account.collection')
+            ->with('collection_status', __('frontend.account_collection_saved'));
+    }
+}

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -14,8 +14,13 @@ class AccountController extends Controller
 {
     public function index(Request $request): View
     {
+        $user = $request->user();
+
         return view('account.index', [
-            'user' => $request->user(),
+            'user' => $user,
+            'statOwnedExpansions' => $user->userExpansions()->count(),
+            'statShuffleCount' => $user->shuffleHistories()->count(),
+            'statPresetCount' => $user->shufflePresets()->count(),
         ]);
     }
 

--- a/app/Http/Controllers/AccountShuffleHistoryController.php
+++ b/app/Http/Controllers/AccountShuffleHistoryController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class AccountShuffleHistoryController extends Controller
+{
+    /**
+     * Recent shuffle results for the account.
+     */
+    public function index(Request $request): View
+    {
+        $user = $request->user();
+
+        $history = $user->shuffleHistories()
+            ->orderByDesc('created_at')
+            ->limit(50)
+            ->get();
+
+        return view('account.history', [
+            'user' => $user,
+            'history' => $history,
+        ]);
+    }
+}

--- a/app/Http/Controllers/AccountShufflePresetController.php
+++ b/app/Http/Controllers/AccountShufflePresetController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\ShufflePreset;
+use App\Services\ShuffleDeckPool;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class AccountShufflePresetController extends Controller
+{
+    public function __construct(
+        private readonly ShuffleDeckPool $shufflePool
+    ) {}
+
+    /**
+     * List presets and show create form.
+     */
+    public function index(Request $request): View
+    {
+        $user = $request->user();
+        $factions = $this->shufflePool->baseQuery($user)->orderBy('name')->get();
+
+        return view('account.presets', [
+            'user' => $user,
+            'presets' => $user->shufflePresets()->orderBy('name')->get(),
+            'factions' => $factions,
+        ]);
+    }
+
+    /**
+     * Store a new shuffle preset.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+        $allowedNames = $this->shufflePool->baseQuery($user)->pluck('name')->all();
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:100'],
+            'player_count' => ['required', 'integer', 'in:2,3,4'],
+            'include_factions' => ['nullable', 'array'],
+            'include_factions.*' => ['string'],
+            'exclude_factions' => ['nullable', 'array'],
+            'exclude_factions.*' => ['string'],
+        ]);
+
+        $include = array_values(array_intersect($validated['include_factions'] ?? [], $allowedNames));
+        $exclude = array_values(array_intersect($validated['exclude_factions'] ?? [], $allowedNames));
+
+        $user->shufflePresets()->create([
+            'name' => $validated['name'],
+            'player_count' => $validated['player_count'],
+            'include_factions' => $include === [] ? null : $include,
+            'exclude_factions' => $exclude === [] ? null : $exclude,
+        ]);
+
+        return redirect()
+            ->route('account.presets')
+            ->with('preset_status', __('frontend.account_preset_saved'));
+    }
+
+    /**
+     * Delete a preset.
+     */
+    public function destroy(Request $request, ShufflePreset $preset): RedirectResponse
+    {
+        if ($preset->user_id !== $request->user()->id) {
+            abort(403);
+        }
+
+        $preset->delete();
+
+        return redirect()
+            ->route('account.presets')
+            ->with('preset_status', __('frontend.account_preset_deleted'));
+    }
+}

--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -3,13 +3,21 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use App\Models\Deck;
+use App\Models\ShuffleHistory;
+use App\Services\ShuffleDeckPool;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use App\Models\Deck;
-use Illuminate\Http\Request;
 
 class DeckController extends Controller
 {
+    public function __construct(
+        private readonly ShuffleDeckPool $shufflePool
+    ) {}
+
     /**
      * Index action to send the factions to the view
      * @return \Illuminate\Contracts\View\View
@@ -102,18 +110,26 @@ class DeckController extends Controller
     }
 
     /**
-     * Quick-shuffle two players using all available factions.
-     * @return \Illuminate\Contracts\View\View
+     * Quick-shuffle two players using the eligible faction pool (respects logged-in user's collection).
      */
-    public function quickShuffle(): \Illuminate\Contracts\View\View
+    public function quickShuffle(Request $request): View
     {
-        $decks = Deck::all()->shuffle();
+        $user = $request->user();
+        $decks = $this->shufflePool->eligibleDecks($user, [], [])->shuffle();
         $selectedDecks = [];
 
         for ($i = 0; $i < 2; $i++) {
             $selectedDecks[] = $decks->splice(0, 2)
                 ->map(fn ($d) => ['name' => $d->name])
                 ->toArray();
+        }
+
+        if ($user !== null) {
+            ShuffleHistory::query()->create([
+                'user_id' => $user->id,
+                'player_count' => 2,
+                'results' => $selectedDecks,
+            ]);
         }
 
         return view('shuffle.shuffle-decks', compact('selectedDecks'));
@@ -207,26 +223,25 @@ class DeckController extends Controller
     }
 
     /**
-     * Shuffle action to shuffle random factions and assign to players
-     * @param Request $request Request object
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Contracts\View\View
+     * Shuffle action to shuffle random factions and assign to players.
+     *
+     * @return RedirectResponse|View
      */
-    public function shuffle(Request $request): \Illuminate\Http\RedirectResponse|\Illuminate\Contracts\View\View
+    public function shuffle(Request $request): RedirectResponse|View
     {
-        $numberOfPlayers = $request->input('numberOfPlayers');
-        $includedFactions = $request->input('includeFactions', []);
-        $excludedFactions = $request->input('excludeFactions', []);
+        $numberOfPlayers = (int) $request->input('numberOfPlayers');
+        $includedFactions = array_values(array_filter((array) $request->input('includeFactions', [])));
+        $excludedFactions = array_values(array_filter((array) $request->input('excludeFactions', [])));
 
-        $decks = Deck::when(!empty($includedFactions), function ($query) use ($includedFactions) {
-                return $query->whereIn('name', $includedFactions);
-            })
-            ->when(!empty($excludedFactions), function ($query) use ($excludedFactions) {
-                return $query->whereNotIn('name', $excludedFactions);
-            })
-            ->get();
+        if (! in_array($numberOfPlayers, [2, 3, 4], true)) {
+            return back()->with('error', __('frontend.shuffle_error_invalid_players'));
+        }
+
+        $user = $request->user();
+        $decks = $this->shufflePool->eligibleDecks($user, $includedFactions, $excludedFactions);
 
         if ($decks->count() < $numberOfPlayers * 2) {
-            return back()->with('error', 'Not enough factions available for the selected number of players.');
+            return back()->with('error', __('frontend.shuffle_error_not_enough_factions'));
         }
 
         $selectedDecks = [];
@@ -237,6 +252,14 @@ class DeckController extends Controller
                 return ['name' => $deck->name];
             })->toArray();
             $decks = $decks->diff($playerDecks);
+        }
+
+        if ($user !== null) {
+            ShuffleHistory::query()->create([
+                'user_id' => $user->id,
+                'player_count' => $numberOfPlayers,
+                'results' => $selectedDecks,
+            ]);
         }
 
         return view('shuffle.shuffle-decks', ['selectedDecks' => $selectedDecks]);

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -1,20 +1,49 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
-use App\Models\Deck;
+use App\Models\ShufflePreset;
+use App\Services\ShuffleDeckPool;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 class HomeController extends Controller
 {
-    /**
-     * Display the home page.
-     *
-     * @return \Illuminate\View\View
-     */
-    public function index()
-    {
-        $factions = Deck::all();
+    public function __construct(
+        private readonly ShuffleDeckPool $shufflePool
+    ) {}
 
-        return view('start.home', compact('factions'));
+    /**
+     * Display the home page (shuffle wizard uses faction list filtered by the user's collection when set).
+     */
+    public function index(Request $request): View
+    {
+        $user = $request->user();
+        $shufflePresetPayload = null;
+        $openShuffleWithPreset = false;
+
+        if ($user !== null && $request->filled('shuffle_preset')) {
+            $preset = ShufflePreset::query()
+                ->where('user_id', $user->id)
+                ->find($request->integer('shuffle_preset'));
+            if ($preset !== null) {
+                $shufflePresetPayload = [
+                    'player_count' => $preset->player_count,
+                    'include' => $preset->include_factions ?? [],
+                    'exclude' => $preset->exclude_factions ?? [],
+                ];
+                $openShuffleWithPreset = true;
+            }
+        }
+
+        $factions = $this->shufflePool->baseQuery($user)->orderBy('name')->get();
+
+        return view('start.home', compact(
+            'factions',
+            'shufflePresetPayload',
+            'openShuffleWithPreset'
+        ));
     }
 }

--- a/app/Models/ShuffleHistory.php
+++ b/app/Models/ShuffleHistory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ShuffleHistory extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'player_count',
+        'results',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'results' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/ShufflePreset.php
+++ b/app/Models/ShufflePreset.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ShufflePreset extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'name',
+        'player_count',
+        'include_factions',
+        'exclude_factions',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'include_factions' => 'array',
+            'exclude_factions' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Passport\Contracts\OAuthenticatable;
@@ -50,5 +51,53 @@ class User extends Authenticatable implements MustVerifyEmail, OAuthenticatable
     {
         return $this->two_factor_secret !== null
             && $this->two_factor_confirmed_at !== null;
+    }
+
+    /**
+     * Expansion sets the user marked as owned (drives shuffle pool when non-empty).
+     *
+     * @return HasMany<UserExpansion, $this>
+     */
+    public function userExpansions(): HasMany
+    {
+        return $this->hasMany(UserExpansion::class);
+    }
+
+    /**
+     * @return HasMany<ShufflePreset, $this>
+     */
+    public function shufflePresets(): HasMany
+    {
+        return $this->hasMany(ShufflePreset::class);
+    }
+
+    /**
+     * @return HasMany<ShuffleHistory, $this>
+     */
+    public function shuffleHistories(): HasMany
+    {
+        return $this->hasMany(ShuffleHistory::class);
+    }
+
+    /**
+     * Whether the user configured at least one owned expansion (shuffle uses this pool).
+     */
+    public function hasExpansionCollection(): bool
+    {
+        return $this->userExpansions()->exists();
+    }
+
+    /**
+     * Distinct expansion names selected for this user (matches `decks.expansion`).
+     *
+     * @return list<string>
+     */
+    public function ownedExpansionNames(): array
+    {
+        return $this->userExpansions()
+            ->pluck('expansion')
+            ->unique()
+            ->values()
+            ->all();
     }
 }

--- a/app/Models/UserExpansion.php
+++ b/app/Models/UserExpansion.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserExpansion extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'expansion',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/ShuffleDeckPool.php
+++ b/app/Services/ShuffleDeckPool.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Deck;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+class ShuffleDeckPool
+{
+    /**
+     * Base query for factions available to the user before include/exclude filters.
+     *
+     * @return Builder<Deck>
+     */
+    public function baseQuery(?User $user): Builder
+    {
+        $query = Deck::query();
+
+        if ($user !== null && $user->hasExpansionCollection()) {
+            $query->whereIn('expansion', $user->ownedExpansionNames());
+        }
+
+        return $query;
+    }
+
+    /**
+     * Factions eligible for shuffle after include/exclude (faction names) are applied.
+     *
+     * @param  list<string>  $includedFactions
+     * @param  list<string>  $excludedFactions
+     * @return Collection<int, Deck>
+     */
+    public function eligibleDecks(?User $user, array $includedFactions, array $excludedFactions): Collection
+    {
+        $query = $this->baseQuery($user);
+
+        if ($includedFactions !== []) {
+            $query->whereIn('name', $includedFactions);
+        }
+
+        if ($excludedFactions !== []) {
+            $query->whereNotIn('name', $excludedFactions);
+        }
+
+        return $query->get();
+    }
+}

--- a/database/migrations/2026_04_14_224345_create_user_expansions_table.php
+++ b/database/migrations/2026_04_14_224345_create_user_expansions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_expansions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('expansion');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'expansion']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_expansions');
+    }
+};

--- a/database/migrations/2026_04_14_224346_create_shuffle_presets_table.php
+++ b/database/migrations/2026_04_14_224346_create_shuffle_presets_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('shuffle_presets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->unsignedTinyInteger('player_count');
+            $table->json('include_factions')->nullable();
+            $table->json('exclude_factions')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('shuffle_presets');
+    }
+};

--- a/database/migrations/2026_04_14_224347_create_shuffle_histories_table.php
+++ b/database/migrations/2026_04_14_224347_create_shuffle_histories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('shuffle_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedTinyInteger('player_count');
+            $table->json('results');
+            $table->timestamps();
+
+            $table->index(['user_id', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('shuffle_histories');
+    }
+};

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,9 +30,13 @@ High-level product and engineering priorities. Update this file in the same PR w
 
 ## Next
 
-- **Faction collection** — Authenticated users select which expansion sets they own; shuffle uses their personal card pool by default.
-- **Shuffle presets** — Save named shuffle configurations (player count + included/excluded factions) to re-use at future game nights.
-- **Play history** — Store past shuffle results per user; view recent faction pairings.
+- *(Open — add items as priorities emerge.)*
+
+## Shipped (account & shuffle)
+
+- **Faction collection** ✅ — `/account/collection`: users tick owned expansion sets; when at least one is saved, `ShuffleDeckPool` constrains the home wizard, `POST /shuffle/result`, and `/random` to factions from those expansions.
+- **Shuffle presets** ✅ — `/account/presets`: named presets (players + optional include/exclude); **Use in shuffle** opens `/?shuffle_preset={id}` and pre-fills the dialog.
+- **Play history** ✅ — `/account/history`: last 50 shuffles while logged in (`shuffle_histories` table).
 
 ## First release readiness
 

--- a/docs/tickets/2026-04-14-account-collection-presets-play-history.md
+++ b/docs/tickets/2026-04-14-account-collection-presets-play-history.md
@@ -1,0 +1,21 @@
+## Title
+Add faction collection, shuffle presets, and play history for logged-in users
+
+## Summary
+Ship the three authenticated features described on the account dashboard: users mark which expansion sets they own (shuffle pool), save named shuffle configurations, and view recent shuffle results. Shuffle and `/random` respect the collection when configured.
+
+## Background / Context
+- Roadmap **Next** items: faction collection, shuffle presets, play history.
+- Shuffle today uses `DeckController::shuffle` / `quickShuffle` over all factions unless include/exclude are posted.
+
+## Requirements
+- [ ] Persist per-user owned expansions; when at least one is saved, constrain shuffle/random pools and home wizard faction lists to those expansions.
+- [ ] CRUD shuffle presets (name, player count, include/exclude faction names) with apply-from-home via query param.
+- [ ] Store each shuffle result for authenticated users; list recent plays on a history page.
+- [ ] Account dashboard shows real counts and links; bilingual EN/DE strings.
+
+## Testing
+- PHPUnit: pool filtering, preset ownership, history creation on shuffle.
+
+## Impact / Risks
+- New migrations; existing guests unchanged.

--- a/resources/lang/de/frontend.php
+++ b/resources/lang/de/frontend.php
@@ -278,21 +278,66 @@ return [
     'account_email_verified'    => 'Deine E-Mail-Adresse wurde bestätigt.',
     'account_features_soon'     => 'Weitere Funktionen kommen bald',
     'account_features_soon_sub' => 'Fraktionssammlung, Shuffle-Voreinstellungen und Spielverlauf sind in Arbeit.',
+    'account_features_heading'  => 'Deine Werkzeuge',
 
     // Account page — additional strings
     'account_profile_section'      => 'Profil',
     'account_role'                 => 'Kontotyp',
     'account_stat_factions'        => 'Fraktionen besessen',
-    'account_stat_shuffles'        => 'Shuffles durchgeführt',
+    'account_stat_expansions'      => 'Erweiterungen in der Sammlung',
+    'account_stat_presets'         => 'Gespeicherte Presets',
+    'account_stat_shuffles'        => 'Geloggte Shuffles',
     'account_stat_history'         => 'Spiele gespielt',
     'account_coming_soon_badge'    => 'Demnächst',
     'account_feat_collection_title' => 'Fraktionssammlung',
     'account_feat_collection_body'  => 'Markiere die Erweiterungen, die du besitzt, damit der Randomizer nur aus deiner Sammlung zieht.',
+    'account_feat_collection_cta'   => 'Sammlung verwalten',
     'account_feat_presets_title'   => 'Shuffle-Voreinstellungen',
     'account_feat_presets_body'    => 'Speichere benannte Konfigurationen — Spieleranzahl, enthaltene Sets — für zukünftige Spieleabende.',
+    'account_feat_presets_cta'     => 'Presets verwalten',
     'account_feat_history_title'   => 'Spielverlauf',
     'account_feat_history_body'    => 'Durchstöbere vergangene Shuffle-Ergebnisse und sieh, welche Fraktionskombinationen deine Gruppe gespielt hat.',
+    'account_feat_history_cta'     => 'Verlauf ansehen',
     'account_quick_actions'        => 'Schnellzugriff',
+
+    // Account — Sammlung
+    'account_collection_back'     => 'Zurück zum Account',
+    'account_collection_heading'    => 'Deine Sammlung',
+    'account_collection_sub'      => 'Wähle, welche Smash-Up-Erweiterungen du physisch besitzt.',
+    'account_collection_hint'     => 'Wenn mindestens ein Set gespeichert ist, nutzen der Shuffle-Assistent und der Schnell-Shuffle nur Fraktionen aus diesen Erweiterungen (Include/Exclude schränken weiter ein).',
+    'account_collection_save'     => 'Sammlung speichern',
+    'account_collection_saved'    => 'Sammlung aktualisiert.',
+    'account_collection_no_expansions' => 'Keine Erweiterungen in der Datenbank gefunden.',
+
+    // Account — Presets
+    'account_presets_back'        => 'Zurück zum Account',
+    'account_presets_heading'     => 'Shuffle-Presets',
+    'account_presets_sub'         => 'Speichere Spieleranzahl und optionale Include-/Exclude-Listen — dann öffnest du den Shuffle von der Startseite mit einem Klick.',
+    'account_preset_saved'        => 'Preset gespeichert.',
+    'account_preset_deleted'      => 'Preset gelöscht.',
+    'account_preset_delete'       => 'Löschen',
+    'account_preset_delete_confirm' => 'Dieses Preset löschen?',
+    'account_preset_apply'        => 'Im Shuffle nutzen',
+    'account_preset_meta'         => ':players Spieler',
+    'account_preset_form_heading' => 'Neues Preset',
+    'account_preset_name_label'   => 'Preset-Name',
+    'account_preset_players_label' => 'Spieler',
+    'account_preset_include_label' => 'Nur diese Fraktionen einschließen (optional)',
+    'account_preset_exclude_label' => 'Diese Fraktionen immer ausschließen (optional)',
+    'account_preset_optional_hint' => 'Include leer lassen, um alle Fraktionen aus deiner Sammlung zuzulassen.',
+    'account_preset_submit'       => 'Preset speichern',
+
+    // Account — Spielverlauf
+    'account_history_back'        => 'Zurück zum Account',
+    'account_history_heading'     => 'Spielverlauf',
+    'account_history_sub'         => 'Letzte Shuffles, während du angemeldet warst (max. 50).',
+    'account_history_empty'       => 'Noch keine Shuffles. Starte einen Shuffle auf der Startseite oder unter /random — angemeldet.',
+    'account_history_players'     => ':n Spieler',
+    'account_history_player_label' => 'Spieler :num',
+
+    // Shuffle-Validierung
+    'shuffle_error_invalid_players' => 'Bitte eine gültige Spieleranzahl wählen.',
+    'shuffle_error_not_enough_factions' => 'Nicht genug Fraktionen für die gewählte Spieleranzahl.',
 
     // Account — Bearbeitungsseite
     'account_edit_page_heading'         => 'Account bearbeiten',

--- a/resources/lang/en/frontend.php
+++ b/resources/lang/en/frontend.php
@@ -296,21 +296,66 @@ return [
     'account_email_verified'    => 'Your e-mail has been verified.',
     'account_features_soon'     => 'More features coming soon',
     'account_features_soon_sub' => 'Faction collection, shuffle presets, and play history are on their way.',
+    'account_features_heading'  => 'Your tools',
 
     // Account page — additional strings
     'account_profile_section'      => 'Profile',
     'account_role'                 => 'Account type',
     'account_stat_factions'        => 'Factions owned',
-    'account_stat_shuffles'        => 'Shuffles done',
+    'account_stat_expansions'      => 'Expansions in collection',
+    'account_stat_presets'         => 'Saved presets',
+    'account_stat_shuffles'        => 'Shuffles logged',
     'account_stat_history'         => 'Games played',
     'account_coming_soon_badge'    => 'Coming soon',
     'account_feat_collection_title' => 'Faction collection',
     'account_feat_collection_body'  => 'Mark the expansion sets you own so the randomizer only draws from your collection.',
+    'account_feat_collection_cta'   => 'Manage collection',
     'account_feat_presets_title'   => 'Shuffle presets',
     'account_feat_presets_body'    => 'Save named configurations — player count, included sets — to reuse at future game nights.',
+    'account_feat_presets_cta'     => 'Manage presets',
     'account_feat_history_title'   => 'Play history',
     'account_feat_history_body'    => 'Browse past shuffle results and see which faction combos your group has played.',
+    'account_feat_history_cta'     => 'View history',
     'account_quick_actions'        => 'Quick actions',
+
+    // Account — collection
+    'account_collection_back'     => 'Back to account',
+    'account_collection_heading'    => 'Your collection',
+    'account_collection_sub'      => 'Select which Smash Up expansion sets you physically own.',
+    'account_collection_hint'     => 'When at least one set is saved, the shuffle wizard and quick shuffle only use factions from those expansions (you can still narrow further with include/exclude).',
+    'account_collection_save'     => 'Save collection',
+    'account_collection_saved'    => 'Collection updated.',
+    'account_collection_no_expansions' => 'No expansions found in the database.',
+
+    // Account — presets
+    'account_presets_back'        => 'Back to account',
+    'account_presets_heading'     => 'Shuffle presets',
+    'account_presets_sub'         => 'Save player count and optional include/exclude lists, then open the home shuffle with one click.',
+    'account_preset_saved'        => 'Preset saved.',
+    'account_preset_deleted'      => 'Preset removed.',
+    'account_preset_delete'       => 'Delete',
+    'account_preset_delete_confirm' => 'Delete this preset?',
+    'account_preset_apply'        => 'Use in shuffle',
+    'account_preset_meta'         => ':players players',
+    'account_preset_form_heading' => 'New preset',
+    'account_preset_name_label'   => 'Preset name',
+    'account_preset_players_label' => 'Players',
+    'account_preset_include_label' => 'Include only these factions (optional)',
+    'account_preset_exclude_label' => 'Always exclude these factions (optional)',
+    'account_preset_optional_hint' => 'Leave include empty to allow any faction from your collection.',
+    'account_preset_submit'       => 'Save preset',
+
+    // Account — play history
+    'account_history_back'        => 'Back to account',
+    'account_history_heading'     => 'Play history',
+    'account_history_sub'         => 'Recent shuffles while you were signed in (up to 50).',
+    'account_history_empty'       => 'No shuffles recorded yet. Run a shuffle from the home page or /random while logged in.',
+    'account_history_players'     => ':n players',
+    'account_history_player_label' => 'Player :num',
+
+    // Shuffle validation
+    'shuffle_error_invalid_players' => 'Please choose a valid player count.',
+    'shuffle_error_not_enough_factions' => 'Not enough factions available for the selected number of players.',
 
     // Account — edit page
     'account_edit_page_heading'         => 'Edit account',

--- a/resources/views/account/collection.blade.php
+++ b/resources/views/account/collection.blade.php
@@ -1,0 +1,51 @@
+<x-layouts.main>
+    <div class="relative min-h-screen bg-zinc-950 pt-14" style="padding-bottom: 6rem">
+        <div class="sur-account-radial-bg" aria-hidden="true"></div>
+        <x-sur.container class="relative z-10 max-w-3xl">
+            <div class="mb-8">
+                <a href="{{ route('account') }}" class="mb-5 inline-flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-300">
+                    <i class="fa-solid fa-arrow-left text-xs" aria-hidden="true"></i>
+                    {{ __('frontend.account_collection_back') }}
+                </a>
+                <h1 class="text-xl font-bold text-white">{{ __('frontend.account_collection_heading') }}</h1>
+                <p class="mt-2 text-sm text-zinc-500">{{ __('frontend.account_collection_sub') }}</p>
+            </div>
+
+            @if(session('collection_status'))
+                <div class="mb-6 flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-400">
+                    <i class="fa-solid fa-circle-check shrink-0" aria-hidden="true"></i>
+                    {{ session('collection_status') }}
+                </div>
+            @endif
+
+            <form method="POST" action="{{ route('account.collection.update') }}" class="rounded-2xl border border-white/10 bg-white/[0.04] p-7 shadow-xl">
+                @csrf
+                @method('PUT')
+
+                <p class="mb-6 text-sm leading-relaxed text-zinc-400">{{ __('frontend.account_collection_hint') }}</p>
+
+                <div class="mb-8 max-h-[28rem] space-y-2 overflow-y-auto rounded-xl border border-white/10 bg-zinc-900/40 p-4 sur-scrollbar">
+                    @forelse($expansions as $expansion)
+                        <label class="flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 transition hover:bg-white/5">
+                            <input
+                                type="checkbox"
+                                name="expansions[]"
+                                value="{{ $expansion }}"
+                                class="h-4 w-4 rounded border-white/20 bg-zinc-800 text-indigo-500 focus:ring-indigo-500/50"
+                                @checked(in_array($expansion, $selectedExpansions, true))
+                            >
+                            <span class="text-sm text-zinc-200">{{ $expansion }}</span>
+                        </label>
+                    @empty
+                        <p class="text-sm text-zinc-500">{{ __('frontend.account_collection_no_expansions') }}</p>
+                    @endforelse
+                </div>
+
+                <button type="submit" class="sur-btn-primary inline-flex min-h-12 items-center gap-2 px-6 text-sm font-semibold">
+                    <i class="fa-solid fa-floppy-disk text-xs" aria-hidden="true"></i>
+                    {{ __('frontend.account_collection_save') }}
+                </button>
+            </form>
+        </x-sur.container>
+    </div>
+</x-layouts.main>

--- a/resources/views/account/history.blade.php
+++ b/resources/views/account/history.blade.php
@@ -1,0 +1,40 @@
+<x-layouts.main>
+    <div class="relative min-h-screen bg-zinc-950 pt-14" style="padding-bottom: 6rem">
+        <div class="sur-account-radial-bg" aria-hidden="true"></div>
+        <x-sur.container class="relative z-10 max-w-3xl">
+            <div class="mb-8">
+                <a href="{{ route('account') }}" class="mb-5 inline-flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-300">
+                    <i class="fa-solid fa-arrow-left text-xs" aria-hidden="true"></i>
+                    {{ __('frontend.account_history_back') }}
+                </a>
+                <h1 class="text-xl font-bold text-white">{{ __('frontend.account_history_heading') }}</h1>
+                <p class="mt-2 text-sm text-zinc-500">{{ __('frontend.account_history_sub') }}</p>
+            </div>
+
+            @if($history->isEmpty())
+                <p class="rounded-2xl border border-white/10 bg-white/[0.04] px-6 py-12 text-center text-sm text-zinc-500">{{ __('frontend.account_history_empty') }}</p>
+            @else
+                <ul class="space-y-4">
+                    @foreach($history as $row)
+                        <li class="rounded-2xl border border-white/10 bg-white/[0.04] p-5">
+                            <div class="mb-3 flex flex-wrap items-center justify-between gap-2 text-xs text-zinc-500">
+                                <span>{{ $row->created_at->timezone(config('app.timezone'))->format('Y-m-d H:i') }}</span>
+                                <span class="rounded-full bg-zinc-800 px-2 py-0.5 text-zinc-400">{{ __('frontend.account_history_players', ['n' => $row->player_count]) }}</span>
+                            </div>
+                            <div class="space-y-2">
+                                @foreach($row->results as $pi => $pair)
+                                    <div class="flex flex-wrap items-center gap-2 text-sm">
+                                        <span class="text-zinc-500">{{ __('frontend.account_history_player_label', ['num' => $pi + 1]) }}</span>
+                                        @foreach($pair as $slot)
+                                            <span class="rounded-lg border border-indigo-500/30 bg-indigo-500/10 px-2.5 py-1 text-indigo-200">{{ $slot['name'] }}</span>
+                                        @endforeach
+                                    </div>
+                                @endforeach
+                            </div>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </x-sur.container>
+    </div>
+</x-layouts.main>

--- a/resources/views/account/index.blade.php
+++ b/resources/views/account/index.blade.php
@@ -53,38 +53,36 @@
                 <div class="mb-6 grid grid-cols-3 gap-4">
                     @php
                         $stats = [
-                            ['icon' => 'fa-layer-group',       'bg' => 'bg-indigo-500/15', 'ring' => 'ring-indigo-500/20', 'text' => 'text-indigo-300', 'label' => __('frontend.account_stat_factions'), 'value' => '—'],
-                            ['icon' => 'fa-shuffle',           'bg' => 'bg-violet-500/15', 'ring' => 'ring-violet-500/20', 'text' => 'text-violet-300', 'label' => __('frontend.account_stat_shuffles'), 'value' => '—'],
-                            ['icon' => 'fa-clock-rotate-left', 'bg' => 'bg-sky-500/15',    'ring' => 'ring-sky-500/20',    'text' => 'text-sky-300',    'label' => __('frontend.account_stat_history'),  'value' => '—'],
+                            ['icon' => 'fa-layer-group',       'bg' => 'bg-indigo-500/15', 'ring' => 'ring-indigo-500/20', 'text' => 'text-indigo-300', 'label' => __('frontend.account_stat_expansions'), 'value' => (string) $statOwnedExpansions, 'href' => route('account.collection')],
+                            ['icon' => 'fa-bookmark',          'bg' => 'bg-violet-500/15', 'ring' => 'ring-violet-500/20', 'text' => 'text-violet-300', 'label' => __('frontend.account_stat_presets'), 'value' => (string) $statPresetCount, 'href' => route('account.presets')],
+                            ['icon' => 'fa-clock-rotate-left', 'bg' => 'bg-sky-500/15',    'ring' => 'ring-sky-500/20',    'text' => 'text-sky-300',    'label' => __('frontend.account_stat_shuffles'), 'value' => (string) $statShuffleCount, 'href' => route('account.history')],
                         ];
                     @endphp
                     @foreach($stats as $stat)
-                        <div class="flex flex-col items-center gap-4 rounded-2xl border border-white/10 bg-white/[0.04] py-14 text-center shadow-lg shadow-black/20 backdrop-blur-sm">
-                            <span class="flex h-12 w-12 items-center justify-center rounded-2xl {{ $stat['bg'] }} {{ $stat['text'] }} ring-1 {{ $stat['ring'] }}">
+                        <a href="{{ $stat['href'] }}" class="group flex flex-col items-center gap-4 rounded-2xl border border-white/10 bg-white/[0.04] py-14 text-center shadow-lg shadow-black/20 backdrop-blur-sm transition hover:border-indigo-500/35 hover:bg-white/[0.07]">
+                            <span class="flex h-12 w-12 items-center justify-center rounded-2xl {{ $stat['bg'] }} {{ $stat['text'] }} ring-1 {{ $stat['ring'] }} transition group-hover:scale-105">
                                 <i class="fa-solid {{ $stat['icon'] }} text-lg" aria-hidden="true"></i>
                             </span>
                             <div>
                                 <p class="text-2xl font-bold leading-none text-white">{{ $stat['value'] }}</p>
                                 <p class="mt-2 text-xs font-medium text-zinc-500">{{ $stat['label'] }}</p>
                             </div>
-                        </div>
+                        </a>
                     @endforeach
                 </div>
             </x-sur.reveal>
 
-            {{-- Coming soon features --}}
+            {{-- Logged-in features --}}
             <x-sur.reveal>
                 <div class="mb-6">
                     <div class="mb-4 flex items-center justify-between">
-                        <h2 class="text-sm font-semibold text-zinc-400">{{ __('frontend.account_features_soon') }}</h2>
-                        <span class="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold text-indigo-400 ring-1 ring-indigo-500/25">
-                            {{ __('frontend.account_coming_soon_badge') }}
-                        </span>
+                        <h2 class="text-sm font-semibold text-zinc-400">{{ __('frontend.account_features_heading') }}</h2>
                     </div>
                     <div class="grid gap-4 sm:grid-cols-3">
                         @php
                             $features = [
                                 [
+                                    'href'    => route('account.collection'),
                                     'icon'    => 'fa-layer-group',
                                     'bg'      => 'bg-indigo-500/15',
                                     'ring'    => 'ring-indigo-500/20',
@@ -92,8 +90,10 @@
                                     'glow'    => 'from-indigo-900/30',
                                     'title'   => __('frontend.account_feat_collection_title'),
                                     'body'    => __('frontend.account_feat_collection_body'),
+                                    'cta'     => __('frontend.account_feat_collection_cta'),
                                 ],
                                 [
+                                    'href'    => route('account.presets'),
                                     'icon'    => 'fa-bookmark',
                                     'bg'      => 'bg-violet-500/15',
                                     'ring'    => 'ring-violet-500/20',
@@ -101,8 +101,10 @@
                                     'glow'    => 'from-violet-900/30',
                                     'title'   => __('frontend.account_feat_presets_title'),
                                     'body'    => __('frontend.account_feat_presets_body'),
+                                    'cta'     => __('frontend.account_feat_presets_cta'),
                                 ],
                                 [
+                                    'href'    => route('account.history'),
                                     'icon'    => 'fa-clock-rotate-left',
                                     'bg'      => 'bg-sky-500/15',
                                     'ring'    => 'ring-sky-500/20',
@@ -110,20 +112,25 @@
                                     'glow'    => 'from-sky-900/30',
                                     'title'   => __('frontend.account_feat_history_title'),
                                     'body'    => __('frontend.account_feat_history_body'),
+                                    'cta'     => __('frontend.account_feat_history_cta'),
                                 ],
                             ];
                         @endphp
                         @foreach($features as $feat)
-                            <div class="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-6 shadow-lg shadow-black/20 backdrop-blur-sm">
+                            <a href="{{ $feat['href'] }}" class="group relative block overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-6 shadow-lg shadow-black/20 backdrop-blur-sm transition hover:border-indigo-500/35 hover:bg-white/[0.06]">
                                 <div class="pointer-events-none absolute inset-0 bg-gradient-to-b {{ $feat['glow'] }} to-transparent opacity-60" aria-hidden="true"></div>
                                 <div class="relative">
-                                    <span class="mb-5 flex h-12 w-12 items-center justify-center rounded-2xl {{ $feat['bg'] }} {{ $feat['text'] }} ring-1 {{ $feat['ring'] }}">
+                                    <span class="mb-5 flex h-12 w-12 items-center justify-center rounded-2xl {{ $feat['bg'] }} {{ $feat['text'] }} ring-1 {{ $feat['ring'] }} transition group-hover:scale-105">
                                         <i class="fa-solid {{ $feat['icon'] }} text-lg" aria-hidden="true"></i>
                                     </span>
                                     <h3 class="mb-2 text-sm font-semibold text-white">{{ $feat['title'] }}</h3>
                                     <p class="text-xs leading-relaxed text-zinc-500">{{ $feat['body'] }}</p>
+                                    <span class="mt-4 inline-flex items-center gap-1.5 text-xs font-semibold text-indigo-400 group-hover:text-indigo-300">
+                                        {{ $feat['cta'] }}
+                                        <i class="fa-solid fa-arrow-right text-[0.65rem] transition group-hover:translate-x-0.5" aria-hidden="true"></i>
+                                    </span>
                                 </div>
-                            </div>
+                            </a>
                         @endforeach
                     </div>
                 </div>

--- a/resources/views/account/presets.blade.php
+++ b/resources/views/account/presets.blade.php
@@ -1,0 +1,110 @@
+<x-layouts.main>
+    <div class="relative min-h-screen bg-zinc-950 pt-14" style="padding-bottom: 6rem">
+        <div class="sur-account-radial-bg" aria-hidden="true"></div>
+        <x-sur.container class="relative z-10 max-w-4xl">
+            <div class="mb-8">
+                <a href="{{ route('account') }}" class="mb-5 inline-flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-300">
+                    <i class="fa-solid fa-arrow-left text-xs" aria-hidden="true"></i>
+                    {{ __('frontend.account_presets_back') }}
+                </a>
+                <h1 class="text-xl font-bold text-white">{{ __('frontend.account_presets_heading') }}</h1>
+                <p class="mt-2 text-sm text-zinc-500">{{ __('frontend.account_presets_sub') }}</p>
+            </div>
+
+            @if(session('preset_status'))
+                <div class="mb-6 flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-400">
+                    <i class="fa-solid fa-circle-check shrink-0" aria-hidden="true"></i>
+                    {{ session('preset_status') }}
+                </div>
+            @endif
+
+            @if($presets->isNotEmpty())
+                <div class="mb-10 space-y-3">
+                    @foreach($presets as $preset)
+                        <div class="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/[0.04] p-5 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <p class="font-semibold text-white">{{ $preset->name }}</p>
+                                <p class="mt-1 text-xs text-zinc-500">
+                                    {{ __('frontend.account_preset_meta', ['players' => $preset->player_count]) }}
+                                </p>
+                            </div>
+                            <div class="flex flex-wrap gap-2">
+                                <a href="{{ route('home', ['shuffle_preset' => $preset->id]) }}" class="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500">
+                                    <i class="fa-solid fa-wand-magic-sparkles text-xs" aria-hidden="true"></i>
+                                    {{ __('frontend.account_preset_apply') }}
+                                </a>
+                                <form method="POST" action="{{ route('account.presets.destroy', $preset) }}" onsubmit="return confirm({{ json_encode(__('frontend.account_preset_delete_confirm')) }})">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="inline-flex items-center gap-2 rounded-xl border border-white/10 px-4 py-2 text-sm text-zinc-400 transition hover:border-red-500/40 hover:text-red-400">
+                                        {{ __('frontend.account_preset_delete') }}
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+
+            <div class="rounded-2xl border border-white/10 bg-white/[0.04] p-7 shadow-xl">
+                <h2 class="mb-6 text-lg font-semibold text-white">{{ __('frontend.account_preset_form_heading') }}</h2>
+                <form method="POST" action="{{ route('account.presets.store') }}" class="space-y-6">
+                    @csrf
+
+                    <div>
+                        <label for="preset_name" class="mb-1.5 block text-xs font-semibold uppercase tracking-wide text-zinc-400">{{ __('frontend.account_preset_name_label') }}</label>
+                        <input type="text" name="name" id="preset_name" value="{{ old('name') }}" required maxlength="100" class="w-full rounded-xl border border-white/10 bg-zinc-900/60 px-4 py-2.5 text-sm text-white outline-none focus:border-indigo-500/60 @error('name') border-red-500/40 @enderror">
+                        @error('name')
+                            <p class="mt-1 text-xs text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <p class="mb-3 text-xs font-semibold uppercase tracking-wide text-zinc-400">{{ __('frontend.account_preset_players_label') }}</p>
+                        <div class="flex flex-wrap gap-3">
+                            @foreach ([2, 3, 4] as $n)
+                                <label class="flex cursor-pointer items-center gap-2 rounded-xl border border-white/10 px-4 py-2 text-sm text-zinc-300 has-[:checked]:border-indigo-500/60 has-[:checked]:bg-indigo-500/10">
+                                    <input type="radio" name="player_count" value="{{ $n }}" class="text-indigo-500" @checked(old('player_count', '2') == (string) $n) required>
+                                    {{ $n }} {{ __('frontend.shuffle_wizard_players_unit') }}
+                                </label>
+                            @endforeach
+                        </div>
+                        @error('player_count')
+                            <p class="mt-1 text-xs text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">{{ __('frontend.account_preset_include_label') }}</p>
+                        <p class="mb-3 text-xs text-zinc-600">{{ __('frontend.account_preset_optional_hint') }}</p>
+                        <div class="max-h-48 space-y-1 overflow-y-auto rounded-xl border border-white/10 bg-zinc-900/40 p-3 sur-scrollbar">
+                            @foreach($factions as $faction)
+                                <label class="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-zinc-300 hover:bg-white/5">
+                                    <input type="checkbox" name="include_factions[]" value="{{ $faction->name }}" class="rounded border-white/20" @checked(collect(old('include_factions', []))->contains($faction->name))>
+                                    {{ $faction->name }}
+                                </label>
+                            @endforeach
+                        </div>
+                    </div>
+
+                    <div>
+                        <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">{{ __('frontend.account_preset_exclude_label') }}</p>
+                        <div class="max-h-48 space-y-1 overflow-y-auto rounded-xl border border-white/10 bg-zinc-900/40 p-3 sur-scrollbar">
+                            @foreach($factions as $faction)
+                                <label class="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs text-zinc-300 hover:bg-white/5">
+                                    <input type="checkbox" name="exclude_factions[]" value="{{ $faction->name }}" class="rounded border-white/20" @checked(collect(old('exclude_factions', []))->contains($faction->name))>
+                                    {{ $faction->name }}
+                                </label>
+                            @endforeach
+                        </div>
+                    </div>
+
+                    <button type="submit" class="sur-btn-primary inline-flex min-h-12 items-center gap-2 px-6 text-sm font-semibold">
+                        <i class="fa-solid fa-plus text-xs" aria-hidden="true"></i>
+                        {{ __('frontend.account_preset_submit') }}
+                    </button>
+                </form>
+            </div>
+        </x-sur.container>
+    </div>
+</x-layouts.main>

--- a/resources/views/start/home.blade.php
+++ b/resources/views/start/home.blade.php
@@ -634,6 +634,10 @@
 </x-layouts.main>
 
 <script>
+    window.__SUR_SHUFFLE_PRESET__ = @json($shufflePresetPayload ?? null);
+    window.__SUR_OPEN_SHUFFLE_WITH_PRESET__ = @json($openShuffleWithPreset ?? false);
+</script>
+<script>
     document.addEventListener('DOMContentLoaded', () => {
         const shuffleDialog = document.getElementById('shuffle-modal');
         /**
@@ -852,6 +856,35 @@
 
         shuffleDialog?.addEventListener('close', nudgeViewportAfterShuffleDialogClose);
 
+        /** Apply saved preset (player count + include/exclude checkboxes). */
+        function applyShufflePreset(preset) {
+            if (!preset || typeof preset !== 'object') {
+                return;
+            }
+            const pc = preset.player_count;
+            if (pc) {
+                const radio = document.querySelector(`input[name="numberOfPlayers"][value="${pc}"]`);
+                if (radio) {
+                    radio.checked = true;
+                }
+            }
+            const inc = Array.isArray(preset.include) ? preset.include : [];
+            const exc = Array.isArray(preset.exclude) ? preset.exclude : [];
+            document.querySelectorAll('.include-faction').forEach((cb) => {
+                cb.checked = inc.includes(cb.value);
+            });
+            document.querySelectorAll('.exclude-faction').forEach((cb) => {
+                cb.checked = exc.includes(cb.value);
+            });
+        }
+
         resetShuffleWizard();
+        const presetPayload = window.__SUR_SHUFFLE_PRESET__;
+        if (presetPayload) {
+            applyShufflePreset(presetPayload);
+        }
+        if (window.__SUR_OPEN_SHUFFLE_WITH_PRESET__ && shuffleDialog && typeof shuffleDialog.showModal === 'function') {
+            shuffleDialog.showModal();
+        }
     });
 </script>

--- a/routes/frontend-auth.php
+++ b/routes/frontend-auth.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Http\Controllers\AccountCollectionController;
 use App\Http\Controllers\AccountController;
+use App\Http\Controllers\AccountShuffleHistoryController;
+use App\Http\Controllers\AccountShufflePresetController;
 use App\Http\Controllers\AccountTwoFactorController;
 use App\Http\Controllers\Frontend\Auth\FrontendAuthenticatedSessionController;
 use App\Http\Controllers\Frontend\Auth\FrontendTwoFactorChallengeController;
@@ -100,4 +103,22 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::post('/account/two-factor/recovery-codes', [AccountTwoFactorController::class, 'regenerateRecoveryCodes'])
         ->name('account.two-factor.recovery-codes');
+
+    Route::get('/account/collection', [AccountCollectionController::class, 'edit'])
+        ->name('account.collection');
+
+    Route::put('/account/collection', [AccountCollectionController::class, 'update'])
+        ->name('account.collection.update');
+
+    Route::get('/account/presets', [AccountShufflePresetController::class, 'index'])
+        ->name('account.presets');
+
+    Route::post('/account/presets', [AccountShufflePresetController::class, 'store'])
+        ->name('account.presets.store');
+
+    Route::delete('/account/presets/{preset}', [AccountShufflePresetController::class, 'destroy'])
+        ->name('account.presets.destroy');
+
+    Route::get('/account/history', [AccountShuffleHistoryController::class, 'index'])
+        ->name('account.history');
 });

--- a/tests/Feature/Account/AccountShuffleFeaturesTest.php
+++ b/tests/Feature/Account/AccountShuffleFeaturesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Account;
+
+use App\Models\Deck;
+use App\Models\User;
+use App\Models\UserExpansion;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AccountShuffleFeaturesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_access_collection(): void
+    {
+        $this->get(route('account.collection'))->assertRedirect(route('login'));
+    }
+
+    public function test_verified_user_can_save_expansion_collection(): void
+    {
+        $user = User::factory()->create();
+        Deck::query()->create([
+            'name' => 'TestFactionA',
+            'expansion' => 'Core Set',
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->put(route('account.collection.update'), [
+            'expansions' => ['Core Set'],
+        ]);
+
+        $response->assertRedirect(route('account.collection'));
+        $this->assertDatabaseHas('user_expansions', [
+            'user_id' => $user->id,
+            'expansion' => 'Core Set',
+        ]);
+    }
+
+    public function test_shuffle_respects_user_collection(): void
+    {
+        $user = User::factory()->create();
+
+        foreach (['C1', 'C2', 'C3', 'C4'] as $name) {
+            Deck::query()->create(['name' => $name, 'expansion' => 'Core Set']);
+        }
+        foreach (['O1', 'O2', 'O3', 'O4'] as $name) {
+            Deck::query()->create(['name' => $name, 'expansion' => 'Other Set']);
+        }
+
+        UserExpansion::query()->create([
+            'user_id' => $user->id,
+            'expansion' => 'Core Set',
+        ]);
+
+        $this->actingAs($user);
+
+        $this->post(route('shuffle-result'), [
+            'numberOfPlayers' => '2',
+            'includeFactions' => [],
+            'excludeFactions' => [],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('shuffle_histories', [
+            'user_id' => $user->id,
+            'player_count' => 2,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
Implements the three logged-in features from the account dashboard: expansion collection (shuffle pool), named shuffle presets with deep-link to home wizard, and play history logging.

## Ticket
`docs/tickets/2026-04-14-account-collection-presets-play-history.md`

## Roadmap
Updated `docs/roadmap.md` (Next cleared; shipped subsection for these features).

## Public copy
`CHANGELOG.md` [Unreleased], EN/DE `frontend.php`.

## Testing
`ddev exec php artisan test` — 151 tests.

Made with [Cursor](https://cursor.com)