### PR TITLE
fix: landing hero carousel even layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Landing hero carousel:** Demo slides use consistent horizontal padding (clear of arrow controls), centered step labels, even grids for player tiles and faction chips, and a fixed two-column faction row on the “combos” slide so card height stays uniform on small screens.
+
 ### Changed
 
 - **Shuffle wizard & landing copy:** Clarified that **include** is optional (nothing checked = all eligible factions; logged-in users follow **Collection** when set), explained when **exclude** saves clicks, and aligned carousel / how-it-works / FAQ with **faction-level** choices in the dialog (set-level filtering via account collection, not set toggles in the wizard). Bilingual EN/DE.

--- a/resources/views/start/home.blade.php
+++ b/resources/views/start/home.blade.php
@@ -51,11 +51,11 @@
                             aria-roledescription="slide"
                             aria-label="{{ __('frontend.landing_slide_1_title') }}"
                         >
-                            <div class="flex flex-1 flex-col items-center justify-center gap-4 px-6 sm:px-10">
-                                <p class="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-400/90">Step 1</p>
-                                <div class="grid w-full max-w-xs grid-cols-3 gap-3">
+                            <div class="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 px-10 pt-9 pb-2 sm:px-14 sm:pt-10">
+                                <p class="text-center text-xs font-semibold uppercase tracking-[0.2em] text-indigo-400/90">Step 1</p>
+                                <div class="mx-auto grid w-full max-w-[15.5rem] grid-cols-3 gap-2 sm:max-w-sm sm:gap-3">
                                     @foreach([2, 3, 4] as $n)
-                                        <div class="flex flex-col items-center justify-center rounded-2xl border px-2 py-4 text-center
+                                        <div class="flex min-h-[5.25rem] min-w-0 flex-col items-center justify-center rounded-2xl border px-1 py-3 text-center sm:min-h-[6rem] sm:px-2 sm:py-4
                                             {{ $n === 2 ? 'border-indigo-500 bg-indigo-500/15 shadow-lg shadow-indigo-500/20' : 'border-white/15 bg-zinc-900/60' }}">
                                             <span class="text-3xl font-extrabold tabular-nums {{ $n === 2 ? 'text-white' : 'text-zinc-400' }} sm:text-4xl">{{ $n }}</span>
                                             <span class="mt-1 text-[0.65rem] font-medium uppercase tracking-wider {{ $n === 2 ? 'text-indigo-200' : 'text-zinc-600' }}">{{ __('frontend.shuffle_wizard_players_unit') }}</span>
@@ -63,7 +63,7 @@
                                     @endforeach
                                 </div>
                             </div>
-                            <div class="border-t border-white/8 bg-black/40 px-5 py-4 sm:px-7">
+                            <div class="shrink-0 border-t border-white/8 bg-black/40 px-5 py-4 sm:px-7">
                                 <h2 class="text-base font-bold text-white sm:text-xl">{{ __('frontend.landing_slide_1_title') }}</h2>
                                 <p class="mt-1 text-xs leading-relaxed text-zinc-300 sm:text-sm">{{ __('frontend.landing_slide_1_tagline') }}</p>
                             </div>
@@ -79,22 +79,22 @@
                             aria-roledescription="slide"
                             aria-label="{{ __('frontend.landing_slide_2_title') }}"
                         >
-                            <div class="flex flex-1 flex-col justify-center px-6 sm:px-10">
-                                <p class="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-400/90">Step 2</p>
+                            <div class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-10 pt-9 pb-2 sm:px-14 sm:pt-10">
+                                <p class="text-center text-xs font-semibold uppercase tracking-[0.2em] text-indigo-400/90">Step 2</p>
                                 @if($factions->isNotEmpty())
-                                    <div class="flex flex-wrap gap-1.5">
+                                    <div class="mx-auto grid w-full max-w-xl grid-cols-2 gap-2 sm:grid-cols-5 sm:gap-2">
                                         @foreach($factions->take(10) as $idx => $faction)
-                                            <span class="rounded-lg border px-2.5 py-1.5 text-xs font-medium transition
+                                            <span class="flex min-h-[2.85rem] items-center justify-center rounded-lg border px-1.5 py-2 text-center text-[0.625rem] font-medium leading-snug transition sm:min-h-[3rem] sm:px-2 sm:text-xs
                                                 {{ $idx < 6 ? 'border-indigo-500/40 bg-indigo-500/12 text-indigo-200' : 'border-white/10 bg-zinc-800/60 text-zinc-500 line-through' }}">
-                                                {{ $faction->name }}
+                                                <span class="line-clamp-2 break-words">{{ $faction->name }}</span>
                                             </span>
                                         @endforeach
                                     </div>
                                 @else
-                                    <p class="text-sm text-zinc-500">{{ __('frontend.landing_slide_2_tagline') }}</p>
+                                    <p class="text-center text-sm text-zinc-500">{{ __('frontend.landing_slide_2_tagline') }}</p>
                                 @endif
                             </div>
-                            <div class="border-t border-white/8 bg-black/40 px-5 py-4 sm:px-7">
+                            <div class="shrink-0 border-t border-white/8 bg-black/40 px-5 py-4 sm:px-7">
                                 <h2 class="text-base font-bold text-white sm:text-xl">{{ __('frontend.landing_slide_2_title') }}</h2>
                                 <p class="mt-1 text-xs leading-relaxed text-zinc-300 sm:text-sm">{{ __('frontend.landing_slide_2_tagline') }}</p>
                             </div>
@@ -111,32 +111,42 @@
                             aria-label="{{ __('frontend.landing_slide_3_title') }}"
                         >
                             @php $demoFactions = $factions->take(4); @endphp
-                            <div class="flex flex-1 flex-col justify-center gap-3 px-6 sm:px-10">
-                                <p class="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-400/90">Step 3</p>
+                            <div class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-10 pt-9 pb-2 sm:px-14 sm:pt-10">
+                                <p class="text-center text-xs font-semibold uppercase tracking-[0.2em] text-indigo-400/90">Step 3</p>
                                 @if($demoFactions->count() >= 4)
-                                    @foreach([[0,1],[2,3]] as $pi => $pair)
-                                        <div class="rounded-2xl border border-white/10 bg-zinc-800/50 px-4 py-3">
-                                            <p class="mb-2 text-[0.65rem] font-semibold uppercase tracking-wider text-zinc-500">
-                                                {{ str_replace(':n', $pi + 1, __('frontend.landing_slide_player_label')) }}
-                                            </p>
-                                            <div class="flex flex-wrap items-center gap-2">
-                                                <span class="rounded-xl border border-indigo-500/35 bg-indigo-500/12 px-3 py-1.5 text-xs font-semibold text-indigo-200">{{ $demoFactions[$pair[0]]->name }}</span>
-                                                <span class="text-sm font-bold text-zinc-500">+</span>
-                                                <span class="rounded-xl border border-violet-500/35 bg-violet-500/12 px-3 py-1.5 text-xs font-semibold text-violet-200">{{ $demoFactions[$pair[1]]->name }}</span>
+                                    <div class="mx-auto flex w-full max-w-md flex-col gap-3">
+                                        @foreach([[0,1],[2,3]] as $pi => $pair)
+                                            @php
+                                                $nameA = $demoFactions[$pair[0]]->name;
+                                                $nameB = $demoFactions[$pair[1]]->name;
+                                            @endphp
+                                            <div class="flex min-h-[5.75rem] flex-col justify-center rounded-2xl border border-white/10 bg-zinc-800/50 px-4 py-3 sm:min-h-[6rem]">
+                                                <p class="mb-2 text-center text-[0.65rem] font-semibold uppercase tracking-wider text-zinc-500">
+                                                    {{ str_replace(':n', $pi + 1, __('frontend.landing_slide_player_label')) }}
+                                                </p>
+                                                <div class="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-x-2 gap-y-1">
+                                                    <span class="flex min-h-[2.5rem] min-w-0 items-center justify-center rounded-xl border border-indigo-500/35 bg-indigo-500/12 px-2 py-1.5 text-center text-xs font-semibold text-indigo-200" title="{{ $nameA }}">
+                                                        <span class="truncate">{{ $nameA }}</span>
+                                                    </span>
+                                                    <span class="shrink-0 text-sm font-bold text-zinc-500">+</span>
+                                                    <span class="flex min-h-[2.5rem] min-w-0 items-center justify-center rounded-xl border border-violet-500/35 bg-violet-500/12 px-2 py-1.5 text-center text-xs font-semibold text-violet-200" title="{{ $nameB }}">
+                                                        <span class="truncate">{{ $nameB }}</span>
+                                                    </span>
+                                                </div>
                                             </div>
-                                        </div>
-                                    @endforeach
+                                        @endforeach
+                                    </div>
                                 @else
-                                    <p class="text-sm text-zinc-500">{{ __('frontend.landing_slide_3_tagline') }}</p>
+                                    <p class="text-center text-sm text-zinc-500">{{ __('frontend.landing_slide_3_tagline') }}</p>
                                 @endif
                             </div>
-                            <div class="border-t border-white/8 bg-black/40 px-5 py-4 sm:px-7">
+                            <div class="shrink-0 border-t border-white/8 bg-black/40 px-5 py-4 sm:px-7">
                                 <h2 class="text-base font-bold text-white sm:text-xl">{{ __('frontend.landing_slide_3_title') }}</h2>
                                 <p class="mt-1 text-xs leading-relaxed text-zinc-300 sm:text-sm">{{ __('frontend.landing_slide_3_tagline') }}</p>
                             </div>
                         </div>
 
-                        <div class="pointer-events-none absolute inset-x-0 top-4 flex justify-center gap-1.5 sm:justify-end sm:px-5">
+                        <div class="pointer-events-none absolute inset-x-0 top-4 flex justify-center gap-1.5">
                             @foreach([0, 1, 2] as $idx)
                                 <button
                                     type="button"
@@ -151,7 +161,7 @@
 
                         <button
                             type="button"
-                            class="sur-landing-carousel-btn absolute left-2 top-1/2 z-10 -translate-y-1/2 sm:left-3"
+                            class="sur-landing-carousel-btn absolute left-2 z-10 top-[42%] -translate-y-1/2 sm:left-3 sm:top-[44%]"
                             @click="prev()"
                             aria-label="{{ __('frontend.landing_carousel_prev') }}"
                         >
@@ -159,7 +169,7 @@
                         </button>
                         <button
                             type="button"
-                            class="sur-landing-carousel-btn absolute right-2 top-1/2 z-10 -translate-y-1/2 sm:right-3"
+                            class="sur-landing-carousel-btn absolute right-2 z-10 top-[42%] -translate-y-1/2 sm:right-3 sm:top-[44%]"
                             @click="next()"
                             aria-label="{{ __('frontend.landing_carousel_next') }}"
                         >


### PR DESCRIPTION
## Summary
Evens out the marketing hero demo carousel: spacing vs arrow controls, centered step labels, grid-based faction chips, uniform combo rows, centered dots, and arrow vertical alignment above the footer strip.

## Testing
`ddev exec php artisan test --filter HomeLandingTest`

## Roadmap
N/A

## Public copy
CHANGELOG only (no new lang keys).

Made with [Cursor](https://cursor.com)