### PR TITLE
chore: pin immutable 5.1.5 (prototype pollution)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project are documented in this file.
 
 ### Security
 
+- **immutable (prototype pollution):** Pinned transitive **`immutable`** to **5.1.5** via npm **`overrides`** (was 5.1.4) to pick up fixes for unsafe handling of `__proto__` in merge / `Map.toJS` / `Map.toObject` paths used by the optional Sass toolchain.
+
 - **Rollup (CVE-2026-27606 / GHSA-mw96-cpmx-2vgc):** Added an explicit **`rollup`** devDependency at **≥ 4.59** (resolved to 4.60.x) so the Vite build no longer uses a vulnerable Rollup 4.53.x. Mitigates arbitrary file write via path traversal in crafted output chunk/asset names during bundling.
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1848,9 +1848,9 @@
             "license": "ISC"
         },
         "node_modules/immutable": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-            "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
             "dev": true,
             "license": "MIT",
             "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
     "private": true,
+    "overrides": {
+        "immutable": "5.1.5"
+    },
     "scripts": {
         "dev": "vite",
         "build": "vite build"


### PR DESCRIPTION
## Summary
Pins transitive `immutable` to **5.1.5** via npm `overrides` so the optional Sass dependency chain no longer resolves to vulnerable **5.1.4**.

## Roadmap
N/A (dependency security chore)

## Public copy
CHANGELOG only (operational/security note for maintainers).

## Testing
- `ddev exec php artisan test` — all passed
- `ddev npm run build` — succeeded

Made with [Cursor](https://cursor.com)