### PR TITLE
chore: trim unused npm deps and Vite build defaults

### DIFF
--- a/.cursor/rules/smash-up-full-workflow-detail.mdc
+++ b/.cursor/rules/smash-up-full-workflow-detail.mdc
@@ -202,6 +202,6 @@ git push -u origin <branch-name>
 
 ## Project-specific stack (reminder)
 
-- Laravel 13, **PHP 8.3+**, **MariaDB 10.4 in DDEV**, Blade, Sanctum & Passport, **Vite 5**, **Tailwind CSS 4** (`@tailwindcss/vite`), jQuery/Alpine (Node **20+**).
+- Laravel 13, **PHP 8.3+**, **MariaDB 10.4 in DDEV**, Blade, Sanctum & Passport, **Vite 5**, **Tailwind CSS 4** (`@tailwindcss/vite`), Alpine.js (Node **20+**).
 - Bilingual: maintain **EN and DE** for user-facing strings under **`resources/lang/`** (do not add a second `lang/` tree at the repo root).
 - **Canonical onboarding:** `README.md` (DDEV hostname: `smash-up-randomizer.ddev.site`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
-- **Design system doc:** [`docs/design-system.md`](docs/design-system.md) now documents **all** foundations — typography (Nunito weights, roles, FA6), color semantics + hardcoded hex/rgba, spacing, touch targets, radii, **motion** (reveal, footer, shuffle wizard, reduced-motion, `animate.css` status), z-index, scrollbars, breakpoints — plus **shuffle dialog**, **cookie layer**, **CKEditor** admin theme, backend shell sizing, and a **complete `sur-*` / related CSS register** from `app.css`.
+- **npm / Vite:** Removed unused **`jquery`**, **`lodash`** (devDependency), and **`animate.css`**; dropped the Animate.css import from `resources/css/app.css` (no `animate__*` classes in first-party views). **Vite:** `build.reportCompressedSize: false` and `chunkSizeWarningLimit: 700` for faster production builds and CI. README, [`docs/design-system.md`](docs/design-system.md) motion sections, and `.cursor/rules/smash-up-full-workflow-detail.mdc` stack line updated.
+
+- **Design system doc:** [`docs/design-system.md`](docs/design-system.md) now documents **all** foundations — typography (Nunito weights, roles, FA6), color semantics + hardcoded hex/rgba, spacing, touch targets, radii, **motion** (reveal, footer, shuffle wizard, reduced-motion; no bundled Animate.css), z-index, scrollbars, breakpoints — plus **shuffle dialog**, **cookie layer**, **CKEditor** admin theme, backend shell sizing, and a **complete `sur-*` / related CSS register** from `app.css`.
 
 - **Blade UI / design system:** Public account overview, 2FA setup, saved presets, expansion detail shuffle CTA, faction detail empty-state + footer shuffle CTA, backend faction edit + wizard form + manager filters/CSV, contact/about submit CTAs, and footer contact chip now use **`sur-btn-*`** / **`sur-input`** instead of raw indigo Tailwind; extra **`hover:scale`** on **`sur-btn-primary`** (contact/about) removed so hover matches the shared button token.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Blade under `resources/views/`: `start/`, `shuffle/`, `decks/`, `frontend/`, `ba
 ### Frontend assets
 
 - **Vite** (`vite.config.js`): `@tailwindcss/vite` plugin + `laravel-vite-plugin`; global styles in `resources/css/app.css` (`@import "tailwindcss"`, design tokens in `@theme`, PostCSS for Autoprefixer only)
-- **Stack**: Tailwind CSS 4, Alpine.js, jQuery (legacy where present), Font Awesome, animate.css (see `package.json`)
+- **Stack**: Tailwind CSS 4, Alpine.js, Font Awesome (see `package.json`)
 
 ### Email
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -132,7 +132,7 @@ Single source of truth for **UI foundations** (typography, color, spacing, motio
 
 **`prefers-reduced-motion: reduce`** (`app.css`): global rule sets `animation-duration`, `transition-duration`, and `scroll-behavior` to effectively instant/auto for `*`, `::before`, `::after`. **Do not** bypass for essential feedback without an accessible alternative.
 
-**`animate.css`:** Imported in `app.css` but **no `animate__*` classes** are used in first-party views. Do not add Animate.css utilities without documenting them here and verifying reduced-motion behavior.
+**Third-party animation libraries:** None are bundled; motion uses Tailwind utilities, `app.css` keyframes, and Alpine-driven classes. If Animate.css or similar is ever added back, document `animate__*` usage here and verify reduced-motion behavior.
 
 **Marketing-only motion:** Landing hero may use **`hover:scale`** / **`active:scale`** on top of `sur-btn-primary` (see [Buttons § Hero emphasis](#hero-emphasis-glow-tier)). Inner pages should stay on default button motion unless the block is explicitly hero-style.
 
@@ -467,7 +467,6 @@ Alphabetical (includes `@layer components` and critical global hooks). **Impleme
 |------|-----------|
 | `sur-panel-auth`, `sur-panel-glass`, `sur-tile-grid` | Extract when the same 7+ token string appears in 3+ files |
 | `sur-checkbox`, `sur-btn-danger`, `sur-flash-*` | Extract when usage grows |
-| `animate.css` | Remove import if still unused, or document any new `animate__*` usage |
 
 **Aligned in code:** Auth and account forms use `sur-input` / `sur-btn-*`; public CTAs and faction manager primary actions use `sur-btn-primary`; footer contact uses `sur-btn-ghost` variant.
 

--- a/docs/tickets/2026-04-19-repo-frontend-optimization.md
+++ b/docs/tickets/2026-04-19-repo-frontend-optimization.md
@@ -1,0 +1,33 @@
+## Title
+Trim unused frontend dependencies and CSS imports; tighten Vite production build settings.
+
+## Summary
+Remove npm packages and CSS that are not referenced by the Vite entrypoints or first-party views, update documentation to match, and apply safe Vite `build` defaults to speed CI/production builds. Reduces install size and shipped CSS without changing user-visible behavior.
+
+## Background / Context
+- `package.json` lists **jQuery** and **lodash** with no imports in `resources/js` or Blade.
+- **`animate.css`** is imported in `resources/css/app.css` but `docs/design-system.md` already notes no `animate__*` usage in first-party views.
+- **Font Awesome** remains required (classes used across Blade).
+
+## Requirements
+- [ ] Remove unused npm dependencies (`jquery`, `lodash` if confirmed unused, `animate.css`) and regenerate lockfile.
+- [ ] Remove `@import 'animate.css'` from `resources/css/app.css`.
+- [ ] Adjust `vite.config.js` with safe production build options (no new npm plugins).
+- [ ] Update `README.md` stack line, `docs/design-system.md` motion/residual sections, and `CHANGELOG.md` `[Unreleased]` for this internal chore.
+- [ ] `ddev npm run build` succeeds; `ddev exec php artisan test` passes (no PHP logic change expected).
+
+## Technical notes
+- Affected paths: `package.json`, `package-lock.json`, `resources/css/app.css`, `vite.config.js`, `README.md`, `docs/design-system.md`, `CHANGELOG.md`, `.cursor/rules/smash-up-full-workflow-detail.mdc`.
+- Do not add new npm dependencies; rely on Vite built-in `build` options only.
+- Public copy: N/A (no new user-facing strings). Roadmap: N/A (chore not tied to Now/Next).
+
+## Testing
+- **PHPUnit:** `ddev exec php artisan test` — full suite; expect green with no test edits.
+- **Manual:** `ddev npm run build`; spot-check home page if time permits (optional — no UI change intended).
+
+## Impact / Risks
+- **Low:** Smaller CSS bundle; if any forgotten `animate__*` reference existed, animation would disappear — grep confirms none in `resources/views`.
+- Rollback: restore previous `package.json` / lock / `app.css` import.
+
+## Plan
+Plan: skipped — no migration, new route, controller, or added dependency; dependency removal and docs follow existing chore patterns (see `CHANGELOG` axios removal).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,16 +7,13 @@
             "dependencies": {
                 "@alpinejs/collapse": "^3.15.11",
                 "@alpinejs/intersect": "^3.15.11",
-                "@fortawesome/fontawesome-free": "^6.6.0",
-                "animate.css": "^4.1.1",
-                "jquery": "^3.7.1"
+                "@fortawesome/fontawesome-free": "^6.6.0"
             },
             "devDependencies": {
                 "@tailwindcss/vite": "^4.1.0",
                 "alpinejs": "^3.15.11",
                 "autoprefixer": "^10.4.2",
                 "laravel-vite-plugin": "^1.0.1",
-                "lodash": "^4.17.19",
                 "postcss": "^8.4.6",
                 "rollup": "^4.60.1",
                 "tailwindcss": "^4.1.0",
@@ -1519,12 +1516,6 @@
                 "@vue/reactivity": "~3.1.1"
             }
         },
-        "node_modules/animate.css": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-4.1.1.tgz",
-            "integrity": "sha512-+mRmCTv6SbCmtYJCN4faJMNFVNN5EuCTTprDTAo7YzIGji2KADmakjVA3+8mVDkZ2Bf09vayB35lSQIex2+QaQ==",
-            "license": "MIT"
-        },
         "node_modules/autoprefixer": {
             "version": "10.4.22",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.22.tgz",
@@ -1873,12 +1864,6 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
-        "node_modules/jquery": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-            "license": "MIT"
-        },
         "node_modules/laravel-vite-plugin": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.3.0.tgz",
@@ -2169,13 +2154,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/magic-string": {
             "version": "0.30.21",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "alpinejs": "^3.15.11",
         "autoprefixer": "^10.4.2",
         "laravel-vite-plugin": "^1.0.1",
-        "lodash": "^4.17.19",
         "postcss": "^8.4.6",
         "rollup": "^4.60.1",
         "tailwindcss": "^4.1.0",
@@ -24,9 +23,7 @@
     "dependencies": {
         "@alpinejs/collapse": "^3.15.11",
         "@alpinejs/intersect": "^3.15.11",
-        "@fortawesome/fontawesome-free": "^6.6.0",
-        "animate.css": "^4.1.1",
-        "jquery": "^3.7.1"
+        "@fortawesome/fontawesome-free": "^6.6.0"
     },
     "type": "module"
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,7 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap');
 
-@import 'animate.css';
-
 @import '@fortawesome/fontawesome-free/css/all.css';
 
 @import 'tailwindcss';

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,11 @@ import laravel from 'laravel-vite-plugin';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
+    build: {
+        // Faster CI/production builds; gzip reporting is optional for local analysis only
+        reportCompressedSize: false,
+        chunkSizeWarningLimit: 700,
+    },
     plugins: [
         tailwindcss(),
         laravel([


### PR DESCRIPTION
## Summary
Removes unused `jquery`, `lodash`, and `animate.css`; drops Animate.css import from `app.css`. Adds safe Vite `build` options for faster CI/production builds. Updates README, design-system, Cursor workflow stack line, and CHANGELOG.

**Ticket:** `docs/tickets/2026-04-19-repo-frontend-optimization.md`

## Gates
- **Roadmap:** N/A (internal chore)
- **Public copy:** N/A (no user-facing strings)
- **Tests:** `ddev exec php artisan test` — 170 passed
- **Build:** `ddev npm run build` — OK


Made with [Cursor](https://cursor.com)