### PR TITLE
docs: add AGENTS.md with Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Stack overview
+
+Laravel 13 + PHP 8.3 + Vite 5 + Tailwind CSS 4 + Alpine.js. See `README.md` for full details.
+
+### Running the app (without DDEV)
+
+The Cloud VM does not have DDEV. Use `php artisan serve` + `npm run dev` directly:
+
+```bash
+php artisan serve --host=0.0.0.0 --port=8000   # HTTP server
+npm run dev                                       # Vite dev server (HMR)
+```
+
+The `.env` is configured with `DB_CONNECTION=sqlite` and a pre-created `database/database.sqlite` file. No MySQL/MariaDB needed for local dev or tests.
+
+### Database
+
+- **Dev/local:** SQLite at `database/database.sqlite`
+- **Tests:** SQLite `:memory:` (configured in `phpunit.xml`, no extra setup needed)
+- After pulling, run `php artisan migrate` to apply any new migrations to the dev SQLite DB.
+- Seed factions: `php artisan db:seed --class=DeckSeeder` (idempotent, uses `updateOrCreate`)
+
+### Tests
+
+```bash
+php artisan test
+```
+
+All 167 tests use SQLite in-memory — no database server required. The Vite manifest (`public/build/manifest.json`) must exist for Blade `@vite` directives; run `npm run build` once if tests fail with "Vite manifest not found".
+
+### Linting
+
+No Pint or ESLint is configured in this project. The CI workflow (`ci.yml`) only runs tests. PSR-12 is the style convention for PHP.
+
+### Frontend build
+
+- `npm run dev` — Vite dev server with HMR (for development)
+- `npm run build` — production build (generates `public/build/`)
+
+### Gotchas
+
+- `APP_URL` must be `http://127.0.0.1:8000` (not the DDEV hostname) when running outside DDEV.
+- `MATOMO_ENABLED=false` in `.env` to avoid loading external analytics scripts locally.
+- The `.ddev/` directory is not present in this checkout — it's gitignored or only exists on dev machines.
+- The `database/data/factions/` directory contains JSON seed data for all 106 factions.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future cloud agents working on this repository.

## What's included

- Stack overview and service startup commands (without DDEV)
- Database configuration notes (SQLite for dev/tests)
- Test running instructions
- Frontend build commands
- Gotchas and non-obvious caveats for the cloud environment

## Context

This file provides durable context for autonomous cloud agents so they can quickly set up and work in this codebase without DDEV. It documents the SQLite-based local dev setup, test requirements, and environment-specific notes.

## Testing

- ✅ `php artisan test` — 167 tests pass (SQLite in-memory)
- ✅ `npm run build` — Vite production build succeeds
- ✅ `php artisan serve` + `npm run dev` — app loads and serves correctly
- ✅ Faction shuffle demonstrated end-to-end with seeded data

[demo_shuffle_factions_flow.mp4](https://cursor.com/agents/bc-af2a496d-0e65-4a55-9ec3-16708fe5b037/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_shuffle_factions_flow.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af2a496d-0e65-4a55-9ec3-16708fe5b037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af2a496d-0e65-4a55-9ec3-16708fe5b037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

