### PR TITLE
feat: harden contact form against bot spam

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,7 @@ GOOGLE_CLIENT_SECRET=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 # GITHUB_REDIRECT_URI="${APP_URL}/auth/github/callback"
+
+# Cloudflare Turnstile — contact form CAPTCHA (https://dash.cloudflare.com/profile/api-tokens → Turnstile)
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- **Contact form spam hardening:** Five layered bot-protection measures — rate limiting (`throttle:5,10` per IP), server-side session timing (3 s minimum delay, no longer client-controlled), stricter field validation (subject whitelist, 20-char message minimum, `email:rfc,dns`), and **Cloudflare Turnstile** CAPTCHA (invisible to real users; configure via `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY`). Existing honeypot field retained.
+
 ### Added
 
 - **GitHub automation:** **Dependabot** (`.github/dependabot.yml`) opens weekly update PRs for **Composer**, **npm**, and **GitHub Actions**. **CI** runs **`composer audit`** and **`./vendor/bin/pint --test`** after `composer install`. **`laravel/pint`** is a Composer **dev** dependency; PHP style is normalized project-wide to match Pint defaults.

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -4,50 +4,61 @@ namespace App\Http\Controllers;
 
 use App\Models\Contact;
 use App\Services\TransactionalMailService;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\View\View;
 
 class ContactController extends Controller
 {
     /**
-     * Write code on Method
-     *
-     * @return response()
+     * Show the contact form and plant a server-side timing seed in the session.
      */
-    public function index()
+    public function index(): View
     {
+        session(['contact_form_start' => now()->timestamp]);
+
         return view('contact.contactForm');
     }
 
     /**
-     * Write code on Method
-     *
-     * @return response()
+     * Validate and store a contact form submission.
      */
-    public function store(Request $request)
+    public function store(Request $request): RedirectResponse
     {
+        // Honeypot: any bot that fills the hidden field is rejected immediately.
+        if (! empty($request->input('context'))) {
+            return redirect()->back()->with(['error' => 'Spam detected!']);
+        }
+
+        // Timing: reject submissions that arrive before the minimum human delay.
+        $formStart = session('contact_form_start', 0);
+        if (now()->timestamp - $formStart < 3) {
+            return redirect()->back()->with(['error' => 'Spam detected!']);
+        }
+
         $request->validate([
-            'name' => 'required|string|max:255',
-            'email' => 'required|email',
-            'phone' => 'nullable|regex:/^[0-9\s\-()+]+$/',
-            'subject' => 'required|string|max:255',
-            'message' => 'required|string',
+            'name'    => 'required|string|max:255',
+            'email'   => 'required|email:rfc,dns',
+            'phone'   => 'nullable|regex:/^[0-9\s\-()+]+$/',
+            'subject' => 'required|in:Bug report,Missing faction,Feature request,General feedback,Other',
+            'message' => 'required|string|min:20',
         ]);
 
-        if (! empty($request->context)) {
+        // Turnstile CAPTCHA verification.
+        if (! $this->verifyTurnstile($request->input('cf-turnstile-response', ''))) {
             return redirect()->back()->with(['error' => 'Spam detected!']);
         }
 
-        $startTime = $request->input('start_time');
-        if (time() - $startTime < 3) {
-            return redirect()->back()->with(['error' => 'Spam detected!']);
-        }
+        // Timing seed is consumed; renew it so re-submission after error works.
+        session(['contact_form_start' => now()->timestamp]);
 
         $phone = $request->filled('phone') ? (string) $request->input('phone') : null;
 
         Contact::create([
-            'name' => (string) $request->input('name'),
-            'email' => (string) $request->input('email'),
-            'phone' => $phone,
+            'name'    => (string) $request->input('name'),
+            'email'   => (string) $request->input('email'),
+            'phone'   => $phone,
             'subject' => (string) $request->input('subject'),
             'message' => (string) $request->input('message'),
         ]);
@@ -55,9 +66,9 @@ class ContactController extends Controller
         $mailer = new TransactionalMailService;
 
         $mailPayload = [
-            'name' => (string) $request->input('name'),
-            'email' => (string) $request->input('email'),
-            'phone' => $phone,
+            'name'    => (string) $request->input('name'),
+            'email'   => (string) $request->input('email'),
+            'phone'   => $phone,
             'subject' => (string) $request->input('subject'),
             'message' => (string) $request->input('message'),
         ];
@@ -86,5 +97,34 @@ class ContactController extends Controller
 
         return redirect()->back()
             ->with(['success' => 'Thanks for reaching out! We\'ll get back to you within 1–2 business days.']);
+    }
+
+    /**
+     * Verify a Cloudflare Turnstile token.
+     *
+     * Returns true when running in the test environment or when no secret key
+     * is configured (local dev without Turnstile credentials).
+     */
+    private function verifyTurnstile(string $token): bool
+    {
+        if (app()->environment('testing')) {
+            return true;
+        }
+
+        $secret = config('services.turnstile.secret');
+
+        if (empty($secret)) {
+            return true;
+        }
+
+        $response = Http::asForm()->post(
+            'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+            [
+                'secret'   => $secret,
+                'response' => $token,
+            ]
+        );
+
+        return (bool) $response->json('success', false);
     }
 }

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -27,7 +27,7 @@ class ContactController extends Controller
     public function store(Request $request): RedirectResponse
     {
         // Honeypot: any bot that fills the hidden field is rejected immediately.
-        if (!empty($request->input('context'))) {
+        if (! empty($request->input('context'))) {
             return redirect()->back()->with(['error' => 'Spam detected!']);
         }
 
@@ -46,7 +46,7 @@ class ContactController extends Controller
         ]);
 
         // Turnstile CAPTCHA verification.
-        if (!$this->verifyTurnstile($request->input('cf-turnstile-response', ''))) {
+        if (! $this->verifyTurnstile($request->input('cf-turnstile-response', ''))) {
             return redirect()->back()->with(['error' => 'Spam detected!']);
         }
 

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -31,9 +31,9 @@ class ContactController extends Controller
             return redirect()->back()->with(['error' => 'Spam detected!']);
         }
 
-        // Timing: reject submissions that arrive before the minimum human delay.
-        $formStart = session('contact_form_start', 0);
-        if (now()->timestamp - $formStart < 3) {
+        // Timing: reject if the session seed is absent (no GET visit) or too recent.
+        $formStart = session('contact_form_start');
+        if ($formStart === null || now()->timestamp - $formStart < 3) {
             return redirect()->back()->with(['error' => 'Spam detected!']);
         }
 

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -27,7 +27,7 @@ class ContactController extends Controller
     public function store(Request $request): RedirectResponse
     {
         // Honeypot: any bot that fills the hidden field is rejected immediately.
-        if (! empty($request->input('context'))) {
+        if (!empty($request->input('context'))) {
             return redirect()->back()->with(['error' => 'Spam detected!']);
         }
 
@@ -38,15 +38,15 @@ class ContactController extends Controller
         }
 
         $request->validate([
-            'name'    => 'required|string|max:255',
-            'email'   => 'required|email:rfc,dns',
-            'phone'   => 'nullable|regex:/^[0-9\s\-()+]+$/',
+            'name' => 'required|string|max:255',
+            'email' => 'required|email:rfc,dns',
+            'phone' => 'nullable|regex:/^[0-9\s\-()+]+$/',
             'subject' => 'required|in:Bug report,Missing faction,Feature request,General feedback,Other',
             'message' => 'required|string|min:20',
         ]);
 
         // Turnstile CAPTCHA verification.
-        if (! $this->verifyTurnstile($request->input('cf-turnstile-response', ''))) {
+        if (!$this->verifyTurnstile($request->input('cf-turnstile-response', ''))) {
             return redirect()->back()->with(['error' => 'Spam detected!']);
         }
 
@@ -56,9 +56,9 @@ class ContactController extends Controller
         $phone = $request->filled('phone') ? (string) $request->input('phone') : null;
 
         Contact::create([
-            'name'    => (string) $request->input('name'),
-            'email'   => (string) $request->input('email'),
-            'phone'   => $phone,
+            'name' => (string) $request->input('name'),
+            'email' => (string) $request->input('email'),
+            'phone' => $phone,
             'subject' => (string) $request->input('subject'),
             'message' => (string) $request->input('message'),
         ]);
@@ -66,9 +66,9 @@ class ContactController extends Controller
         $mailer = new TransactionalMailService;
 
         $mailPayload = [
-            'name'    => (string) $request->input('name'),
-            'email'   => (string) $request->input('email'),
-            'phone'   => $phone,
+            'name' => (string) $request->input('name'),
+            'email' => (string) $request->input('email'),
+            'phone' => $phone,
             'subject' => (string) $request->input('subject'),
             'message' => (string) $request->input('message'),
         ];
@@ -120,7 +120,7 @@ class ContactController extends Controller
         $response = Http::asForm()->post(
             'https://challenges.cloudflare.com/turnstile/v0/siteverify',
             [
-                'secret'   => $secret,
+                'secret' => $secret,
                 'response' => $token,
             ]
         );

--- a/composer.lock
+++ b/composer.lock
@@ -4162,16 +4162,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.51",
+            "version": "3.0.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748"
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d59c94077f9c9915abb51ddb52ce85188ece1748",
-                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
                 "shasum": ""
             },
             "require": {
@@ -4252,7 +4252,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.51"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
             },
             "funding": [
                 {
@@ -4268,7 +4268,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T01:33:53+00:00"
+            "time": "2026-04-27T07:02:15+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -6062,16 +6062,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -6084,7 +6084,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6109,7 +6109,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -6121,24 +6121,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v7.4.8",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "2918e7c2ba964defca1f5b69c6f74886529e2dc8"
+                "reference": "b59b59122690976550fd142c23fab62c84738db6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/2918e7c2ba964defca1f5b69c6f74886529e2dc8",
-                "reference": "2918e7c2ba964defca1f5b69c6f74886529e2dc8",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/b59b59122690976550fd142c23fab62c84738db6",
+                "reference": "b59b59122690976550fd142c23fab62c84738db6",
                 "shasum": ""
             },
             "require": {
@@ -6177,7 +6181,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v7.4.8"
+                "source": "https://github.com/symfony/dom-crawler/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -6197,7 +6201,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -6283,16 +6287,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.8",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f57b899fa736fd71121168ef268f23c206083f0a"
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f57b899fa736fd71121168ef268f23c206083f0a",
-                "reference": "f57b899fa736fd71121168ef268f23c206083f0a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
                 "shasum": ""
             },
             "require": {
@@ -6344,7 +6348,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.8"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -6364,20 +6368,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:54:39+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -6391,7 +6395,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6424,7 +6428,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -6436,11 +6440,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/finder",
@@ -6691,16 +6699,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab"
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9381209597ec66c25be154cbf2289076e64d1eab",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
                 "shasum": ""
             },
             "require": {
@@ -6749,7 +6757,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6769,20 +6777,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "017e76ad089bac281553389269e259e155935e1a"
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/017e76ad089bac281553389269e259e155935e1a",
-                "reference": "017e76ad089bac281553389269e259e155935e1a",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
                 "shasum": ""
             },
             "require": {
@@ -6868,7 +6876,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6888,20 +6896,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-31T20:57:01+00:00"
+            "time": "2026-05-27T08:31:43+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.8",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/5cefb712a25f320579615ba9e1942abaeade7dff",
+                "reference": "5cefb712a25f320579615ba9e1942abaeade7dff",
                 "shasum": ""
             },
             "require": {
@@ -6952,7 +6960,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -6972,7 +6980,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/mailgun-mailer",
@@ -7049,16 +7057,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "6df02f99998081032da3407a8d6c4e1dcb5d4379"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/6df02f99998081032da3407a8d6c4e1dcb5d4379",
-                "reference": "6df02f99998081032da3407a8d6c4e1dcb5d4379",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
@@ -7114,7 +7122,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.8"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -7134,7 +7142,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T14:11:46+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -7209,16 +7217,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -7268,7 +7276,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -7288,7 +7296,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -7374,16 +7382,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -7437,7 +7445,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7457,20 +7465,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -7522,7 +7530,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -7542,20 +7550,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -7607,7 +7615,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7627,20 +7635,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -7691,7 +7699,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -7711,20 +7719,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "8339098cae28673c15cce00d80734af0453054e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/8339098cae28673c15cce00d80734af0453054e2",
+                "reference": "8339098cae28673c15cce00d80734af0453054e2",
                 "shasum": ""
             },
             "require": {
@@ -7771,7 +7779,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7791,7 +7799,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
@@ -7875,16 +7883,16 @@
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -7931,7 +7939,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -7951,7 +7959,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-23T16:12:55+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
@@ -8265,16 +8273,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "9608de9873ec86e754fb6c0a0fa7e5f1a960eb6b"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/9608de9873ec86e754fb6c0a0fa7e5f1a960eb6b",
-                "reference": "9608de9873ec86e754fb6c0a0fa7e5f1a960eb6b",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -8326,7 +8334,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.8"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -8346,20 +8354,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -8377,7 +8385,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -8413,7 +8421,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -8433,7 +8441,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "symfony/string",
@@ -11533,16 +11541,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883"
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
-                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
                 "shasum": ""
             },
             "require": {
@@ -11585,7 +11593,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.8"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -11605,7 +11613,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-25T06:06:12+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/services.php
+++ b/config/services.php
@@ -54,7 +54,7 @@ return [
 
     'turnstile' => [
         'site_key' => env('TURNSTILE_SITE_KEY', ''),
-        'secret'   => env('TURNSTILE_SECRET_KEY', ''),
+        'secret' => env('TURNSTILE_SECRET_KEY', ''),
     ],
 
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -52,4 +52,9 @@ return [
         'redirect' => env('GITHUB_REDIRECT_URI', env('APP_URL').'/auth/github/callback'),
     ],
 
+    'turnstile' => [
+        'site_key' => env('TURNSTILE_SITE_KEY', ''),
+        'secret'   => env('TURNSTILE_SECRET_KEY', ''),
+    ],
+
 ];

--- a/docs/tickets/2026-05-28-contact-form-spam-hardening.md
+++ b/docs/tickets/2026-05-28-contact-form-spam-hardening.md
@@ -1,0 +1,53 @@
+## Contact Form Spam Hardening
+
+Add layered bot protection to the contact form: rate limiting, session-based timing, stricter validation, and Cloudflare Turnstile CAPTCHA.
+
+## Summary
+
+The contact form is currently hit by automated bots that bypass the existing honeypot and client-side timing check. This ticket hardens the form with five complementary layers — each cheap to implement, collectively effective without friction for real users.
+
+## Background / Context
+
+- Current protection: honeypot field (`context`) + `start_time` hidden field (3 s min). Both are trivially bypassed — bots ignore hidden fields, and the timestamp is fully client-controlled.
+- No rate limiting exists on `POST /contact-us`.
+- Subject is validated as `string|max:255` only — any value accepted; no whitelist.
+- Email validation is syntax-only; disposable/fake domains pass through.
+- Cloudflare Turnstile (free, privacy-friendly, GDPR-compatible) is the nuclear option and the most effective single measure.
+
+## Requirements
+
+- [ ] `POST /contact-us` has a Laravel `throttle:5,10` middleware (5 requests per 10 minutes per IP)
+- [ ] `start_time` is stored in the session server-side (not in the form) and verified on submit; client-controlled value removed
+- [ ] `subject` is validated as `in:Bug report,Missing faction,Feature request,General feedback,Other`
+- [ ] `message` has a `min:20` character constraint
+- [ ] `email` uses `email:rfc,dns` validation rule
+- [ ] Cloudflare Turnstile is integrated: site key rendered in the form, server-side token verification via `Http` facade against `https://challenges.cloudflare.com/turnstile/v0/siteverify`
+- [ ] Turnstile verification is skipped in test environment (`app()->environment('testing')`)
+- [ ] `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` added to `config/services.php` + `.env.example`
+- [ ] Existing honeypot field retained (cheap, layered defense)
+
+## Technical notes
+
+- **No new Composer package** — Turnstile verification uses Laravel's `Http` facade (already available)
+- Affected paths: `routes/web.php`, `app/Http/Controllers/ContactController.php`, `resources/views/contact/contactForm.blade.php`, `config/services.php`, `.env.example`
+- Session key: `contact_form_start` — set on `GET /contact-us`, checked + cleared on successful `POST`
+- Plan: see CreatePlan (Phase 3)
+
+## Testing
+
+- **PHPUnit** (`tests/Feature/ContactFormTest.php`):
+  - Happy path: valid submission passes all layers
+  - Honeypot: `context` filled → rejected
+  - Timing: submitted before session timing window → rejected
+  - Rate limit: 6th request within 10 min → 429
+  - Subject whitelist: invalid value → validation fails
+  - Message too short: < 20 chars → validation fails
+  - Turnstile: mocked `Http` facade — success and failure responses
+- **Manual / browser**: submit form on DDEV, verify Turnstile widget renders, verify valid submission succeeds and spam attempts are blocked
+
+## Impact / Risks
+
+- Turnstile requires `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` in `.env` — without them the form blocks all submissions in non-test envs (guard with fallback or skip when key is empty)
+- DNS email check may slow validation ~50–200 ms; acceptable for a contact form
+- Rate limiting is per-IP — shared NAT / proxies could occasionally hit limit; 5 per 10 min is generous for legit use
+- Rollback: remove Turnstile script + server-side check; revert validation rules; remove throttle middleware

--- a/resources/views/contact/contactForm.blade.php
+++ b/resources/views/contact/contactForm.blade.php
@@ -1,5 +1,9 @@
 <x-layouts.main>
 
+@push('head')
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+@endpush
+
     {{-- Hero --}}
     <section class="relative overflow-hidden bg-linear-to-br from-violet-950/50 via-zinc-950 to-zinc-950 py-20 md:py-24">
         <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_50%_-10%,rgb(139_92_246_/_0.10),transparent)]" aria-hidden="true"></div>
@@ -121,9 +125,15 @@
                             @enderror
                         </div>
 
-                        {{-- Honeypot + timing spam protection --}}
+                        {{-- Honeypot spam protection --}}
                         <input type="text" name="context" id="context" class="hidden" tabindex="-1" autocomplete="off" aria-hidden="true">
-                        <input type="hidden" name="start_time" value="{{ time() }}">
+
+                        {{-- Cloudflare Turnstile CAPTCHA --}}
+                        @if(config('services.turnstile.site_key'))
+                            <div class="cf-turnstile mt-5"
+                                 data-sitekey="{{ config('services.turnstile.site_key') }}"
+                                 data-theme="dark"></div>
+                        @endif
 
                         <div class="mt-7">
                             <button type="submit" class="sur-btn-primary min-h-12 w-full sm:w-auto sm:px-10">

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,7 +93,7 @@ Route::post('contact-us', [
     ContactController::class,
     'store',
 ])
-    ->middleware('throttle:5,1')
+    ->middleware('throttle:5,10')
     ->name('contact.us.store');
 
 Route::get('/factions', [

--- a/tests/Feature/ContactFormTest.php
+++ b/tests/Feature/ContactFormTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Contact;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class ContactFormTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** Valid payload that passes all spam layers. */
+    private function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'name'    => 'Test User',
+            'email'   => 'test@gmail.com',
+            'subject' => 'Bug report',
+            'message' => 'This is a valid test message with enough characters.',
+            'context' => '',
+        ], $overrides);
+    }
+
+    /** Seed the session timing key with a timestamp 10 seconds in the past. */
+    private function seedTiming(int $secondsAgo = 10): void
+    {
+        session(['contact_form_start' => now()->timestamp - $secondsAgo]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Mail::fake();
+        Cache::flush();
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /contact-us
+    // -------------------------------------------------------------------------
+
+    public function test_contact_form_is_accessible(): void
+    {
+        $response = $this->get('/contact-us');
+
+        $response->assertOk();
+        $response->assertSee('contact', false);
+    }
+
+    public function test_contact_page_seeds_session_timing(): void
+    {
+        $before = now()->timestamp;
+
+        $this->get('/contact-us');
+
+        $start = session('contact_form_start');
+        $this->assertNotNull($start);
+        $this->assertGreaterThanOrEqual($before, $start);
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /contact-us — happy path
+    // -------------------------------------------------------------------------
+
+    public function test_valid_submission_stores_contact_and_redirects(): void
+    {
+        $this->seedTiming();
+
+        $response = $this->post('/contact-us', $this->validPayload());
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+        $this->assertDatabaseHas('contacts', ['email' => 'test@gmail.com']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Honeypot
+    // -------------------------------------------------------------------------
+
+    public function test_honeypot_filled_is_rejected(): void
+    {
+        $this->seedTiming();
+
+        $response = $this->post('/contact-us', $this->validPayload(['context' => 'bot-fill']));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+        $this->assertDatabaseMissing('contacts', ['email' => 'test@gmail.com']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Session-based timing
+    // -------------------------------------------------------------------------
+
+    public function test_submission_too_fast_is_rejected(): void
+    {
+        // Seed timing to "just now" so elapsed < 3 s.
+        session(['contact_form_start' => now()->timestamp]);
+
+        $response = $this->post('/contact-us', $this->validPayload());
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+        $this->assertDatabaseMissing('contacts', ['email' => 'test@example.com']);
+    }
+
+    public function test_submission_without_session_timing_is_rejected(): void
+    {
+        // No call to seedTiming() → session key absent → defaults to 0 → always < 3 s.
+        $response = $this->post('/contact-us', $this->validPayload());
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation
+    // -------------------------------------------------------------------------
+
+    public function test_invalid_subject_is_rejected(): void
+    {
+        $this->seedTiming();
+
+        $response = $this->post('/contact-us', $this->validPayload(['subject' => 'Spam subject']));
+
+        $response->assertSessionHasErrors(['subject']);
+    }
+
+    public function test_message_too_short_is_rejected(): void
+    {
+        $this->seedTiming();
+
+        $response = $this->post('/contact-us', $this->validPayload(['message' => 'Too short']));
+
+        $response->assertSessionHasErrors(['message']);
+    }
+
+    public function test_invalid_email_syntax_is_rejected(): void
+    {
+        $this->seedTiming();
+
+        $response = $this->post('/contact-us', $this->validPayload(['email' => 'not-an-email']));
+
+        $response->assertSessionHasErrors(['email']);
+    }
+
+    public function test_required_fields_are_enforced(): void
+    {
+        $this->seedTiming();
+
+        $response = $this->post('/contact-us', []);
+
+        $response->assertSessionHasErrors(['name', 'email', 'subject', 'message']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Rate limiting
+    // -------------------------------------------------------------------------
+
+    public function test_rate_limit_blocks_after_five_requests(): void
+    {
+        // Make 5 valid submissions (each creates a DB record and consumes a rate-limit token).
+        for ($i = 0; $i < 5; $i++) {
+            $this->seedTiming();
+            $this->post('/contact-us', $this->validPayload(['email' => "user{$i}@gmail.com"]));
+        }
+
+        // 6th request must be throttled.
+        $this->seedTiming();
+        $response = $this->post('/contact-us', $this->validPayload(['email' => 'user5@gmail.com']));
+
+        $response->assertStatus(429);
+    }
+
+    // -------------------------------------------------------------------------
+    // Turnstile (auto-passes in test environment)
+    // -------------------------------------------------------------------------
+
+    public function test_turnstile_is_bypassed_in_test_environment(): void
+    {
+        $this->seedTiming();
+
+        // No cf-turnstile-response field — verifyTurnstile() returns true in testing env.
+        $response = $this->post('/contact-us', $this->validPayload());
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+    }
+}

--- a/tests/Feature/ContactFormTest.php
+++ b/tests/Feature/ContactFormTest.php
@@ -18,8 +18,8 @@ class ContactFormTest extends TestCase
     private function validPayload(array $overrides = []): array
     {
         return array_merge([
-            'name'    => 'Test User',
-            'email'   => 'test@gmail.com',
+            'name' => 'Test User',
+            'email' => 'test@gmail.com',
             'subject' => 'Bug report',
             'message' => 'This is a valid test message with enough characters.',
             'context' => '',


### PR DESCRIPTION
## Summary
- Rate limiting: `throttle:5,10` on `POST /contact-us` (5 requests / 10 min per IP)
- Server-side session timing replaces tamper-able client hidden field
- Validation hardened: subject whitelist, `message min:20`, `email:rfc,dns`
- Cloudflare Turnstile CAPTCHA (auto-skipped in test env; configure via `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY`)
- Honeypot field retained
## Test plan
- [ ] `ddev exec php artisan test --filter=ContactFormTest` — all layers green
- [ ] `ddev exec ./vendor/bin/pint --test` — no style violations
- [ ] Manual: submit form on DDEV, Turnstile widget visible, valid submission succeeds
Roadmap: N/A
Public copy: CHANGELOG [Unreleased] updated
Ticket: docs/tickets/2026-05-28-contact-form-spam-hardening.md