### PR TITLE
ci: add PCOV code coverage and Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           php-version: '8.3'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
-          coverage: none
+          coverage: pcov
 
       - name: Get Composer cache directory
         id: composer-cache
@@ -73,4 +73,11 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: php artisan test
+        run: php artisan test --coverage --coverage-clover=coverage.xml
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false


### PR DESCRIPTION
Enables PCOV in CI for code coverage reporting. Generates `coverage.xml` (Clover format) and uploads to Codecov on every CI run. No minimum threshold set yet — baseline will be visible after first green run.

Made with [Cursor](https://cursor.com)