### PR TITLE
chore: optimize full workflow rules

### DIFF
--- a/.cursor/rules/smash-up-full-workflow-detail.mdc
+++ b/.cursor/rules/smash-up-full-workflow-detail.mdc
@@ -66,7 +66,7 @@ Use Cursor **Plan mode** when **any** of the following applies:
 
 - New DB migration
 - New public route or controller
-- More than 5 files changed
+- More than 8 files changed
 - New external dependency
 - Architectural trade-offs with no clear winner
 
@@ -92,11 +92,11 @@ If `dev` is missing, **ask** whether to use `main` or another base.
 
 ## Phase 5 — Implement
 
-- **Before running artisan / Composer / npm:** use `ddev exec …` / `ddev composer …` / `ddev npm run …` (project uses DDEV; see `README.md`). If DDEV cannot be run, list exact commands for the user's machine.
+- **Before running artisan / Composer / npm:** use `php artisan …` / `composer …` / `npm run …` directly (no DDEV required; see `AGENTS.md` for server setup). On a DDEV machine, prefix with `ddev exec` / `ddev composer` / `ddev npm run` as needed.
 - **Laravel:** thin controllers, Form Requests, policies/middleware as needed, Eloquent, strict types, PSR-12, DocBlocks.
 - **Frontend:** Blade + Vite; **vanilla JS** (and Alpine as already used); keep scripts in `resources/js/`.
 - **No** mock/fake data in dev or prod paths (tests only).
-- After migrations in dev: `ddev exec php artisan migrate`.
+- After migrations in dev: `php artisan migrate`.
 - Keep files roughly under 200–300 lines; extract services when justified.
 - **GDPR:** no tracking/analytics without explicit product decision and legal review.
 
@@ -105,15 +105,14 @@ If `dev` is missing, **ask** whether to use `main` or another base.
 ## Phase 6 — Tests
 
 - **PHPUnit:** `tests/Feature`, `tests/Unit`; factories/mocks; no real external services.
-- **Run** tests: `ddev exec php artisan test`. Do not only author tests — run them.
-- **Parallel with Phase 7:** You may run tests and Pint **at the same time** (e.g. two terminals) to save wall time. **Both** must pass before Phase 10.
+- **Run** tests: `php artisan test`. Do not only author tests — run them.
 
 ---
 
 ## Phase 7 — Lint & static analysis
 
-- **PHP:** PSR-12; run `./vendor/bin/pint --test` if Pint is installed (`composer.json`).
-- **JS:** consistent with existing files; run ESLint only if the project already uses it.
+- **PHP:** PSR-12 style convention; no Pint configured in this project.
+- **JS:** consistent with existing files; no ESLint configured in this project.
 - **`ReadLints`** on all changed files before commit.
 
 ---
@@ -202,6 +201,6 @@ git push -u origin <branch-name>
 
 ## Project-specific stack (reminder)
 
-- Laravel 13, **PHP 8.3+**, **MariaDB 10.4 in DDEV**, Blade, Sanctum & Passport, **Vite 6**, **Tailwind CSS 4** (`@tailwindcss/vite`), Alpine.js (Node **20+**).
+- Laravel 13, **PHP 8.3+**, **SQLite** (dev + tests in-memory), Blade, **Vite 5**, **Tailwind CSS 4** (`@tailwindcss/vite`), Alpine.js (Node **20+**).
 - Bilingual: maintain **EN and DE** for user-facing strings under **`resources/lang/`** (do not add a second `lang/` tree at the repo root).
-- **Canonical onboarding:** `README.md` (DDEV hostname: `smash-up-randomizer.ddev.site`).
+- **Authoritative stack + CLI commands:** `AGENTS.md`. Canonical onboarding: `README.md`.

--- a/.cursor/rules/smash-up-full-workflow-detail.mdc
+++ b/.cursor/rules/smash-up-full-workflow-detail.mdc
@@ -56,7 +56,7 @@ Follow **`ticket-authoring.mdc`**.
 
 - `Write` the ticket to `docs/tickets/YYYY-MM-DD-short-slug.md` (content matches chat).
 - **Ticket vs Plan:** Requirements = checkboxes; **Technical notes** short (see ticket-authoring). Do **not** paste the full ordered step list from Plan mode; a cross-reference is enough when Phase 3 runs.
-- **IssueForge (optional, non-blocking):** Only if `.env` defines `ISSUE_FORGE_BASE_URL`, `ISSUE_FORGE_PROJECT_ID`, and `API_ADMIN_TOKEN`. After the ticket file exists, `POST` with `project_id`, `title`, `description`, `status: "open"`, `priority`. On **201**, report id. **Do not** delay Phase 4+ on IssueForge latency; on missing env or failure, note **IssueForge: skipped** and continue.
+- **IssueForge (optional, non-blocking):** Only if `.env` defines `ISSUE_FORGE_BASE_URL`, `ISSUE_FORGE_PROJECT_ID`, and `API_ADMIN_TOKEN`. After the ticket file exists, `POST https://{ISSUE_FORGE_BASE_URL}/api/v1/tickets` with `project_id`, `title`, `description`, `priority` (`low`/`medium`/`high`). Do **not** send `status` — it is set server-side. On **201**, report the returned `id` (e.g. "IssueForge: #67"). **Do not** delay Phase 4+ on IssueForge latency; on missing env or failure, note **IssueForge: skipped** and continue.
 
 ---
 
@@ -202,6 +202,6 @@ git push -u origin <branch-name>
 
 ## Project-specific stack (reminder)
 
-- Laravel 13, **PHP 8.3+**, **MariaDB 10.4 in DDEV**, Blade, Sanctum & Passport, **Vite 5**, **Tailwind CSS 4** (`@tailwindcss/vite`), Alpine.js (Node **20+**).
+- Laravel 13, **PHP 8.3+**, **MariaDB 10.4 in DDEV**, Blade, Sanctum & Passport, **Vite 6**, **Tailwind CSS 4** (`@tailwindcss/vite`), Alpine.js (Node **20+**).
 - Bilingual: maintain **EN and DE** for user-facing strings under **`resources/lang/`** (do not add a second `lang/` tree at the repo root).
 - **Canonical onboarding:** `README.md` (DDEV hostname: `smash-up-randomizer.ddev.site`).

--- a/.cursor/rules/smash-up-full-workflow.mdc
+++ b/.cursor/rules/smash-up-full-workflow.mdc
@@ -21,7 +21,7 @@ alwaysApply: true
 | Small, safe change | **Quick** | Branch from `dev` exists (ticket/plan/roadmap scan skipped). |
 | Anything else | **Full** | **Pre-code gate** below is complete. |
 
-**Quick track** — use when the user says quick fix **or** **all** are true: ≤3 files, no DB migration, no new public route/controller, no guest-visible UX change. Still: branch → implement → **tests** (`ddev exec php artisan test` when PHP/app or test code changed; doc-only may run a quick smoke or skip if nothing executable changed) → lint → commit → push → PR → merge (or defer merge; see detail Phase 13).
+**Quick track** — use when the user says quick fix **or** **all** are true: ≤3 files, no DB migration, no new public route/controller, no guest-visible UX change. Still: branch → implement → **tests** (`php artisan test` when PHP/app or test code changed; doc-only may run a quick smoke or skip if nothing executable changed) → lint → commit → push → PR → merge (or defer merge; see detail Phase 13).
 
 **Prefer Quick** for typos, single-file fixes, and internal refactors that do not hit the Full triggers — less ticket overhead, same quality gates.
 
@@ -49,7 +49,7 @@ Use **any row** in "Full + Plan" as a **Full track** trigger. Use the **Plan col
 |--------|------------|---------------------------|----------------------|
 | New DB migration | Yes | Yes | No |
 | New public route or controller | Yes | Yes | No |
-| More than 5 files changed (expected) | Yes | Yes | No |
+| More than 8 files changed (expected) | Yes | Yes | No |
 | New external dependency | Yes | Yes | No |
 | Guest-visible UX change | Yes | If unclear / trade-offs | No |
 | Architectural / design choice with no obvious winner | Yes (if shipping code) | Yes | No |
@@ -57,7 +57,7 @@ Use **any row** in "Full + Plan" as a **Full track** trigger. Use the **Plan col
 
 **Plan mode skip (Full track):** If the change **follows an existing repo pattern 1:1** (e.g. same controller/Request/Blade shape as a recent feature) and there is **no** migration, **no** new route, **no** dependency, **no** arch fork — skip `CreatePlan`; add one short **Approach** line in the ticket (e.g. "Mirror `FooController` / `store` flow") and proceed to Branch.
 
-**Plan mode (Full track):** Before `SwitchMode(plan)` / `CreatePlan`, confirm **at least one** Plan trigger from the matrix applies. If **none** apply, skip Plan and record one sentence in the ticket (e.g. "Plan: skipped — no migration, route, >5 files, dependency, or arch fork").
+**Plan mode (Full track):** Before `SwitchMode(plan)` / `CreatePlan`, confirm **at least one** Plan trigger from the matrix applies. If **none** apply, skip Plan and record one sentence in the ticket (e.g. "Plan: skipped — no migration, route, >8 files, dependency, or arch fork").
 
 ---
 
@@ -79,7 +79,7 @@ Do **not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` until
 ### Pre-commit gate (all tracks that change code)
 
 ```
-[ ] Tests run (ddev exec php artisan test) + ReadLints on touched files; Pint if present
+[ ] Tests run (`php artisan test`) + ReadLints on touched files
 [ ] Docs: README/docs/CHANGELOG per detail Phase 8
 [ ] Roadmap: updated if Phase 1 scan matched — or valid Roadmap: N/A
 [ ] Public copy: EN/DE lang + CHANGELOG if visitor-notable — or Public copy: N/A
@@ -88,7 +88,6 @@ Do **not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` until
 **Efficiency:**
 
 - While tests run, **draft** `[Unreleased]` bullets and lang keys. **Do not commit** on red tests/lint.
-- **Parallel runs:** When useful, run `ddev exec php artisan test` and `./vendor/bin/pint --test` (if Pint is present) in **parallel** (e.g. two terminals). **Both** must pass before commit.
 - **PR / merge:** Prefer `gh pr create` and, once required checks are **green**, merge in the same session (`gh pr merge --squash --delete-branch`) unless the user deferred merge or CI is still pending (see detail Phase 13).
 
 ---
@@ -112,4 +111,4 @@ Do **not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` until
 
 ## Project stack (reminder)
 
-Laravel 13, PHP 8.3+, DDEV, Blade, Vite 5, Tailwind 4, bilingual `resources/lang/` EN+DE. Onboarding: `README.md`.
+Laravel 13, PHP 8.3+, Blade, Vite 5, Tailwind 4, SQLite (dev + tests), bilingual `resources/lang/` EN+DE. See `AGENTS.md` for authoritative stack details and CLI commands.

--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,9 @@ GITHUB_CLIENT_SECRET=
 # Cloudflare Turnstile — contact form CAPTCHA (https://dash.cloudflare.com/profile/api-tokens → Turnstile)
 TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
+
+# IssueForge — ticket system integration (optional, used by Cursor workflow in Phase 2)
+# Endpoint: POST {ISSUE_FORGE_BASE_URL}/api/v1/tickets
+ISSUE_FORGE_BASE_URL=https://issue-forge.com
+ISSUE_FORGE_PROJECT_ID=
+API_ADMIN_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           php-version: '8.3'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
-          coverage: none
+          coverage: pcov
 
       - name: Get Composer cache directory
         id: composer-cache
@@ -73,4 +73,11 @@ jobs:
         run: npm run build
 
       - name: Run tests
-        run: php artisan test
+        run: php artisan test --coverage --coverage-clover=coverage.xml
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 [![PHP](https://img.shields.io/badge/PHP-8.3+-777BB4?style=flat-square&logo=php&logoColor=white)](https://php.net)
 [![MariaDB](https://img.shields.io/badge/MariaDB-10.4-003545?style=flat-square&logo=mariadb&logoColor=white)](https://mariadb.org)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind-4.x-38bdf8?style=flat-square&logo=tailwindcss&logoColor=white)](https://tailwindcss.com)
-[![Vite](https://img.shields.io/badge/Vite-5.x-646CFF?style=flat-square&logo=vite&logoColor=white)](https://vitejs.dev)
+[![Vite](https://img.shields.io/badge/Vite-6.x-646CFF?style=flat-square&logo=vite&logoColor=white)](https://vitejs.dev)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![GitHub last commit](https://img.shields.io/github/last-commit/kadsuno/smash-up-randomizer?style=flat-square)](https://github.com/kadsuno/smash-up-randomizer/commits)
 [![GitHub issues](https://img.shields.io/github/issues/kadsuno/smash-up-randomizer?style=flat-square)](https://github.com/kadsuno/smash-up-randomizer/issues)
 [![CI](https://github.com/kadsuno/smash-up-randomizer/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/kadsuno/smash-up-randomizer/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Kadsuno/smash-up-randomizer/graph/badge.svg?token=HP6HHG1YC2)](https://codecov.io/gh/Kadsuno/smash-up-randomizer)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=flat-square)](https://conventionalcommits.org)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 


### PR DESCRIPTION
## Summary

Bereinigt beide Workflow-Rule-Files um veraltete und widersprüchliche Anweisungen.

## Changes

- **`ddev exec` → `php artisan`** in allen Gates + Phasen (aligns mit `AGENTS.md`)
- **Pint-Referenzen entfernt** — nicht im Projekt installiert
- **Vite 6 → 5** im Detail-File; **MariaDB → SQLite** (Cloud/lokal)
- **Plan-Mode-Trigger:** Datei-Schwelle 5 → 8 (realistischere Grenze)
- **Stack-Authority** zentralisiert auf `AGENTS.md`; duplikate Stack-Blurbs gestrafft
- Redundantes Parallel-Pint/Test-Bullet aus Pre-commit Gate entfernt

## Roadmap: N/A
## Public copy: N/A

Made with [Cursor](https://cursor.com)