### PR TITLE
chore: fix workflow rules — DDEV primary, Vite 6, MariaDB

### DIFF
--- a/.cursor/rules/smash-up-full-workflow-detail.mdc
+++ b/.cursor/rules/smash-up-full-workflow-detail.mdc
@@ -92,7 +92,7 @@ If `dev` is missing, **ask** whether to use `main` or another base.
 
 ## Phase 5 — Implement
 
-- **Before running artisan / Composer / npm:** use `php artisan …` / `composer …` / `npm run …` directly (no DDEV required; see `AGENTS.md` for server setup). On a DDEV machine, prefix with `ddev exec` / `ddev composer` / `ddev npm run` as needed.
+- **Before running artisan / Composer / npm:** use `ddev exec …` / `ddev composer …` / `ddev npm run …` (project uses DDEV; see `README.md`). If DDEV cannot be run, use `php artisan …` / `composer …` / `npm run …` directly.
 - **Laravel:** thin controllers, Form Requests, policies/middleware as needed, Eloquent, strict types, PSR-12, DocBlocks.
 - **Frontend:** Blade + Vite; **vanilla JS** (and Alpine as already used); keep scripts in `resources/js/`.
 - **No** mock/fake data in dev or prod paths (tests only).
@@ -201,6 +201,6 @@ git push -u origin <branch-name>
 
 ## Project-specific stack (reminder)
 
-- Laravel 13, **PHP 8.3+**, **SQLite** (dev + tests in-memory), Blade, **Vite 5**, **Tailwind CSS 4** (`@tailwindcss/vite`), Alpine.js (Node **20+**).
+- Laravel 13, **PHP 8.3+**, **MariaDB 10.4 in DDEV**, Blade, Sanctum & Passport, **Vite 6**, **Tailwind CSS 4** (`@tailwindcss/vite`), Alpine.js (Node **20+**).
 - Bilingual: maintain **EN and DE** for user-facing strings under **`resources/lang/`** (do not add a second `lang/` tree at the repo root).
-- **Authoritative stack + CLI commands:** `AGENTS.md`. Canonical onboarding: `README.md`.
+- **Canonical onboarding:** `README.md` (DDEV hostname: `smash-up-randomizer.ddev.site`).

--- a/.cursor/rules/smash-up-full-workflow.mdc
+++ b/.cursor/rules/smash-up-full-workflow.mdc
@@ -111,4 +111,4 @@ Do **not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` until
 
 ## Project stack (reminder)
 
-Laravel 13, PHP 8.3+, Blade, Vite 5, Tailwind 4, SQLite (dev + tests), bilingual `resources/lang/` EN+DE. See `AGENTS.md` for authoritative stack details and CLI commands.
+Laravel 13, PHP 8.3+, DDEV (MariaDB 10.4), Blade, Vite 6, Tailwind 4, bilingual `resources/lang/` EN+DE. Onboarding: `README.md`.


### PR DESCRIPTION
## Summary

Korrigiert die falschen Stack-Angaben aus PR #148.

## Changes

- DDEV als primäres Toolchain in Phase 5 wiederhergestellt (mit non-DDEV-Fallback)
- Stack-Reminder beide Files: Vite 6, MariaDB 10.4
- Pint-Referenzen entfernt (nicht installiert)
- Plan-trigger 8 Dateien bleibt erhalten

## Roadmap: N/A
## Public copy: N/A

Made with [Cursor](https://cursor.com)