### PR TITLE
feat: integrate mandatory subagents throughout full workflow

### DIFF
--- a/.cursor/rules/smash-up-full-workflow-detail.mdc
+++ b/.cursor/rules/smash-up-full-workflow-detail.mdc
@@ -36,14 +36,21 @@ Do not implement while blocking questions are unanswered.
 
 ## Phase 1 — Analyze
 
+**Subagent: MUST use `explore`** (`run_in_background: false`, await result before Phase 2).
+
+- Set thoroughness to `medium` for standard features; `very thorough` for large refactors or unfamiliar areas.
+- The subagent searches `app/`, `routes/`, `config/`, `resources/views/`, `resources/js/`, `resources/lang/`, `tests/`, `docs/`.
+- Return from subagent: list of affected files, existing patterns to reuse, risks, test surfaces.
+
+After subagent returns:
+
 1. Classify: feature / bug / chore.
-2. Use codebase search, `Grep`, `Glob`, `Read` for Laravel (`app/`, `routes/`, `config/`), Blade (`resources/views/`), assets (`resources/js`, `resources/sass`), Lang (`resources/lang/` when present), tests (`tests/`).
-3. Reuse existing patterns: thin controllers, Form Requests where appropriate, Eloquent, Blade components, Vite entrypoints, bilingual `__('frontend.key')` / `__('backend.key')`.
-4. **Output:** mental model of affected files, risks, test surfaces.
+2. Reuse existing patterns: thin controllers, Form Requests, Eloquent, Blade components, Vite entrypoints, bilingual `__('frontend.key')` / `__('backend.key')`.
+3. **Output:** mental model of affected files, risks, test surfaces.
 
-5. **Roadmap scan:** Read **`docs/roadmap.md`** **only when** classification = `feature` or the chore explicitly maps to a roadmap bullet. If this change **implements, completes, or materially advances** any item, plan a **`docs/roadmap.md` edit in the same PR** (Phase 8). For bugfixes restoring documented behavior: **Roadmap: N/A** — do **not** open `docs/roadmap.md`.
+4. **Roadmap scan:** Read **`docs/roadmap.md`** **only when** classification = `feature` or the chore explicitly maps to a roadmap bullet. If this change **implements, completes, or materially advances** any item, plan a **`docs/roadmap.md` edit in the same PR** (Phase 8). For bugfixes restoring documented behavior: **Roadmap: N/A** — do **not** open `docs/roadmap.md`.
 
-6. **Public-facing copy (when applicable):** When a change materially affects **guest-visible** UI, landing/legal trust, or headline flows, plan updates in the **same PR** to:
+5. **Public-facing copy (when applicable):** When a change materially affects **guest-visible** UI, landing/legal trust, or headline flows, plan updates in the **same PR** to:
    - **`CHANGELOG.md`** `[Unreleased]` (user-visible notes), and
    - relevant **`resources/lang/en/`** and **`resources/lang/de/`** for new/changed strings.
    If the change is **internal-only** or **invisible to users**, state **Public copy: N/A**.
@@ -66,7 +73,7 @@ Use Cursor **Plan mode** when **any** of the following applies:
 
 - New DB migration
 - New public route or controller
-- More than 5 files changed
+- More than 8 files changed
 - New external dependency
 - Architectural trade-offs with no clear winner
 
@@ -92,7 +99,9 @@ If `dev` is missing, **ask** whether to use `main` or another base.
 
 ## Phase 5 — Implement
 
-- **Before running artisan / Composer / npm:** use `ddev exec …` / `ddev composer …` / `ddev npm run …` (project uses DDEV; see `README.md`). If DDEV cannot be run, list exact commands for the user's machine.
+**Subagent: use `best-of-n-runner`** only when there is genuine architectural uncertainty with no clear winner (e.g. two viable approaches that differ in structure). Each runner gets an isolated worktree. Otherwise implement directly in the parent agent.
+
+- **Before running artisan / Composer / npm:** use `ddev exec …` / `ddev composer …` / `ddev npm run …` (project uses DDEV; see `README.md`). If DDEV cannot be run, use `php artisan …` / `composer …` / `npm run …` directly.
 - **Laravel:** thin controllers, Form Requests, policies/middleware as needed, Eloquent, strict types, PSR-12, DocBlocks.
 - **Frontend:** Blade + Vite; **vanilla JS** (and Alpine as already used); keep scripts in `resources/js/`.
 - **No** mock/fake data in dev or prod paths (tests only).
@@ -104,23 +113,31 @@ If `dev` is missing, **ask** whether to use `main` or another base.
 
 ## Phase 6 — Tests
 
+**Subagent: MUST use `shell`** (`run_in_background: true`).
+
+- Launch the `shell` subagent with `ddev exec php artisan test` immediately after Phase 5.
+- While the subagent runs, the **parent agent executes Phase 8 (Docs draft) in parallel** — do not wait idle.
+- **Await** the shell subagent before Phase 10 (Commit). Tests must be green.
 - **PHPUnit:** `tests/Feature`, `tests/Unit`; factories/mocks; no real external services.
-- **Run** tests: `ddev exec php artisan test`. Do not only author tests — run them.
-- **Parallel with Phase 7:** You may run tests and Pint **at the same time** (e.g. two terminals) to save wall time. **Both** must pass before Phase 10.
+- Do not only author tests — run them.
 
 ---
 
 ## Phase 7 — Lint & static analysis
 
-- **PHP:** PSR-12; run `./vendor/bin/pint --test` if Pint is installed (`composer.json`).
-- **JS:** consistent with existing files; run ESLint only if the project already uses it.
-- **`ReadLints`** on all changed files before commit.
+**No dedicated subagent** — run `ReadLints` in the parent agent on all changed files.
+
+- **PHP:** PSR-12 style convention; no Pint configured in this project.
+- **JS:** consistent with existing files; no ESLint configured in this project.
+- **`ReadLints`** on all changed files before commit. Fix any introduced linter errors.
 
 ---
 
 ## Phase 8 — Docs & changelog (draft vs finalize)
 
-- **Draft (early):** After implement (or in parallel while tests run), prepare **`CHANGELOG.md`** `[Unreleased]` and any obvious **EN/DE** keys so you are not blocked later.
+**No dedicated subagent** — parent agent executes this in parallel while the Phase 6 `shell` subagent runs tests.
+
+- **Draft (early):** While tests run in background, prepare **`CHANGELOG.md`** `[Unreleased]` and any obvious **EN/DE** keys so you are not blocked later.
 - **Finalize:** After Phase 9 (browser) if UI work surfaced copy issues, **update Lang + CHANGELOG** again before commit.
 - Update **`README.md`** / **`docs/`** when behavior or onboarding changes.
 
@@ -135,14 +152,17 @@ Update **only if** Phase 1 triggered a roadmap scan and found a match: move comp
 
 ## Phase 9 — Browser / manual verification
 
-- **UI changes:** use Cursor browser MCP when available; otherwise concrete steps aligned with ticket **Requirements** (include EN/DE if both are affected). Prefer this **after** a docs/lang **draft** so obvious gaps show up in verification.
-- **Backend-only / CLI-only:** state **no browser test required** and rely on automated tests.
+**Subagent: MUST use `generalPurpose`** for UI changes (`run_in_background: false`, await result).
+
+- Give the subagent the ticket Requirements checklist and the DDEV hostname (`smash-up-randomizer.ddev.site`).
+- The subagent verifies EN and DE flows where applicable and reports any copy or layout gaps.
+- **Backend-only / CLI-only:** state **no browser test required**, skip this phase entirely.
 
 ---
 
 ## Phase 10 — Commit
 
-Satisfy the **Pre-commit gate** in **`smash-up-full-workflow.mdc`**.
+Satisfy the **Pre-commit gate** in **`smash-up-full-workflow.mdc`**. Both Phase 6 subagent and Phase 7 `ReadLints` must be complete and green before committing.
 
 - Use **`TodoWrite`** for full workflow runs; do not leave stale `in_progress`.
 - Conventional-style subjects: `feat:`, `fix:`, `chore:`, `docs:`.
@@ -160,14 +180,18 @@ git push -u origin <branch-name>
 
 ## Phase 12 — Pull request (GitHub)
 
+**Subagent: MUST use `shell`** for PR creation (`run_in_background: false`).
+
 - Target **`dev`** unless opted out or another base is agreed.
 - PR body: note **Roadmap** (updated vs N/A) and **Public copy** (CHANGELOG/Lang vs N/A).
-- Prefer **`gh pr create`** when available.
-- **Same-session flow:** When CI is quick or already green, chain **create PR → verify checks → merge** (Phase 13) so the branch does not linger.
+- Use `gh pr create` inside the `shell` subagent.
+- **Same-session flow:** After PR creation, poll CI status and proceed directly to Phase 13 merge in the same shell subagent when checks are green.
 
 ---
 
 ## Phase 13 — Merge (GitHub)
+
+**Subagent: continue in the same `shell` subagent from Phase 12.**
 
 - After PR creation, **attempt merge** when GitHub allows and **required checks are green**, unless the user opted out (`no merge` / `kein Merge`).
 - If checks are **queued or pending:** report PR URL and current status. Either **wait** with bounded polling until green, then merge — or stop with **documented next steps** if the session must end (e.g. "CI pending; merge with `gh pr merge <n> --squash --delete-branch` when green"). **Do not merge** on red or unknown CI unless the user explicitly overrides.
@@ -186,7 +210,8 @@ git push -u origin <branch-name>
 ## Violations — NEVER
 
 - Skip the ticket file (Full track) or use an inline plan instead of `CreatePlan` (when Plan mode applies).
-- Commit without running tests + `ReadLints` for changed code paths.
+- Skip a mandated subagent type or substitute the parent agent where `explore` / `shell` / `generalPurpose` is required.
+- Commit without the Phase 6 `shell` subagent returning green + `ReadLints` clean.
 - Finish after push + PR **without** attempting merge when checks are green and the user did not opt out.
 - Ship roadmap-tracked work without updating `docs/roadmap.md` (unless deferred in ticket + user agreed).
 
@@ -194,9 +219,9 @@ git push -u origin <branch-name>
 
 ## Ordering
 
-**Full track:** Analyze → Ticket → Plan (if triggered) → Branch → Implement → Tests → Lint → Docs (draft) → Browser (if UI) → Docs (finalize) → Commit → Push → PR → Merge → Cleanup.
+**Full track:** Analyze (`explore`) → Ticket → Plan (if triggered) → Branch → Implement → Tests (`shell` bg) ‖ Docs draft (parent) → Lint → Browser (`generalPurpose`, UI only) → Docs finalize → Commit → Push → PR+Merge (`shell`) → Cleanup.
 
-**Quick track:** Branch → Implement → Tests (when PHP/app or test code changed) → Lint → Commit → Push → PR → Merge → Cleanup.
+**Quick track:** Branch → Implement → Tests (`shell` bg) → Lint → Commit → Push → PR → Merge → Cleanup.
 
 ---
 

--- a/.cursor/rules/smash-up-full-workflow.mdc
+++ b/.cursor/rules/smash-up-full-workflow.mdc
@@ -13,6 +13,22 @@ alwaysApply: true
 
 ---
 
+## Subagent map (MUST follow)
+
+Use the correct subagent type for each phase. Launching in the wrong mode or skipping subagents is a workflow violation.
+
+| Phase | Subagent type | Background? | Notes |
+|-------|--------------|-------------|-------|
+| 1 — Analyze | `explore` | No (await result) | thoroughness: medium / very thorough |
+| 5 — Implement | `best-of-n-runner` | No | Only when genuine arch uncertainty; else parent |
+| 6 — Tests | `shell` | **Yes** | Frees parent to run Phase 8 draft in parallel |
+| 9 — Browser | `generalPurpose` | No | UI changes only; skip for backend-only |
+| 12/13 — PR & Merge | `shell` | No | `gh pr create` + CI poll + merge |
+
+**Parallel rule:** Phase 6 (`shell` subagent, background) **and** Phase 8 draft (parent agent) **MUST** run concurrently. Await the shell subagent before Phase 10.
+
+---
+
 ## Track pick (before the first implementation edit)
 
 | Goal | Track | First productive edit allowed when |
@@ -21,7 +37,7 @@ alwaysApply: true
 | Small, safe change | **Quick** | Branch from `dev` exists (ticket/plan/roadmap scan skipped). |
 | Anything else | **Full** | **Pre-code gate** below is complete. |
 
-**Quick track** — use when the user says quick fix **or** **all** are true: ≤3 files, no DB migration, no new public route/controller, no guest-visible UX change. Still: branch → implement → **tests** (`ddev exec php artisan test` when PHP/app or test code changed; doc-only may run a quick smoke or skip if nothing executable changed) → lint → commit → push → PR → merge (or defer merge; see detail Phase 13).
+**Quick track** — use when the user says quick fix **or** **all** are true: ≤3 files, no DB migration, no new public route/controller, no guest-visible UX change. Still: branch → implement → **tests** (`shell` subagent: `ddev exec php artisan test` when PHP/app or test code changed; doc-only may run a quick smoke or skip if nothing executable changed) → lint → commit → push → PR → merge (or defer merge; see detail Phase 13).
 
 **Prefer Quick** for typos, single-file fixes, and internal refactors that do not hit the Full triggers — less ticket overhead, same quality gates.
 
@@ -49,7 +65,7 @@ Use **any row** in "Full + Plan" as a **Full track** trigger. Use the **Plan col
 |--------|------------|---------------------------|----------------------|
 | New DB migration | Yes | Yes | No |
 | New public route or controller | Yes | Yes | No |
-| More than 5 files changed (expected) | Yes | Yes | No |
+| More than 8 files changed (expected) | Yes | Yes | No |
 | New external dependency | Yes | Yes | No |
 | Guest-visible UX change | Yes | If unclear / trade-offs | No |
 | Architectural / design choice with no obvious winner | Yes (if shipping code) | Yes | No |
@@ -57,7 +73,7 @@ Use **any row** in "Full + Plan" as a **Full track** trigger. Use the **Plan col
 
 **Plan mode skip (Full track):** If the change **follows an existing repo pattern 1:1** (e.g. same controller/Request/Blade shape as a recent feature) and there is **no** migration, **no** new route, **no** dependency, **no** arch fork — skip `CreatePlan`; add one short **Approach** line in the ticket (e.g. "Mirror `FooController` / `store` flow") and proceed to Branch.
 
-**Plan mode (Full track):** Before `SwitchMode(plan)` / `CreatePlan`, confirm **at least one** Plan trigger from the matrix applies. If **none** apply, skip Plan and record one sentence in the ticket (e.g. "Plan: skipped — no migration, route, >5 files, dependency, or arch fork").
+**Plan mode (Full track):** Before `SwitchMode(plan)` / `CreatePlan`, confirm **at least one** Plan trigger from the matrix applies. If **none** apply, skip Plan and record one sentence in the ticket (e.g. "Plan: skipped — no migration, route, >8 files, dependency, or arch fork").
 
 ---
 
@@ -68,7 +84,7 @@ Use **any row** in "Full + Plan" as a **Full track** trigger. Use the **Plan col
 Do **not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` until:
 
 ```
-[ ] Phase 1 — Analyze: explored; affected files/patterns known (see detail)
+[ ] Phase 1 — Analyze: explore subagent launched and awaited; affected files/patterns known
 [ ] Phase 2 — Ticket: docs/tickets/YYYY-MM-DD-short-slug.md (ticket-authoring.mdc)
 [ ] Phase 3 — Plan: if matrix says Plan → SwitchMode(plan) + CreatePlan + user confirm; else skip with brief rationale
 [ ] Phase 4 — Branch: from latest dev (see detail)
@@ -79,7 +95,8 @@ Do **not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` until
 ### Pre-commit gate (all tracks that change code)
 
 ```
-[ ] Tests run (ddev exec php artisan test) + ReadLints on touched files; Pint if present
+[ ] shell subagent (background) ran `ddev exec php artisan test` — awaited, green
+[ ] ReadLints on all touched files — clean
 [ ] Docs: README/docs/CHANGELOG per detail Phase 8
 [ ] Roadmap: updated if Phase 1 scan matched — or valid Roadmap: N/A
 [ ] Public copy: EN/DE lang + CHANGELOG if visitor-notable — or Public copy: N/A
@@ -87,23 +104,23 @@ Do **not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` until
 
 **Efficiency:**
 
-- While tests run, **draft** `[Unreleased]` bullets and lang keys. **Do not commit** on red tests/lint.
-- **Parallel runs:** When useful, run `ddev exec php artisan test` and `./vendor/bin/pint --test` (if Pint is present) in **parallel** (e.g. two terminals). **Both** must pass before commit.
-- **PR / merge:** Prefer `gh pr create` and, once required checks are **green**, merge in the same session (`gh pr merge --squash --delete-branch`) unless the user deferred merge or CI is still pending (see detail Phase 13).
+- Launch `shell` subagent for tests (`run_in_background: true`); while it runs, **draft** `[Unreleased]` bullets and lang keys in the parent agent. **Do not commit** until subagent returns green.
+- **PR / merge:** Use a `shell` subagent: `gh pr create`, poll CI, then `gh pr merge --squash --delete-branch` once checks are **green** — unless the user deferred merge or CI is still pending (see detail Phase 13).
 
 ---
 
 ## Ordering (abbreviated)
 
-**Full:** Analyze → Ticket → Plan (if triggered) → Branch → Implement → Tests → Lint → Docs (draft) → Browser (if UI) → Docs (finalize) → Commit → Push → PR → Merge → Cleanup.
+**Full:** Analyze (`explore`) → Ticket → Plan (if triggered) → Branch → Implement → Tests (`shell` bg) ‖ Docs draft (parent) → Lint → Browser (`generalPurpose`, if UI) → Docs finalize → Commit → Push → PR+Merge (`shell`) → Cleanup.
 
-**Quick:** Branch → Implement → Tests (when code warrants) → Lint → Commit → Push → PR → Merge → Cleanup.
+**Quick:** Branch → Implement → Tests (`shell` bg) → Lint → Commit → Push → PR → Merge → Cleanup.
 
 ---
 
 ## Violations — NEVER
 
 - Skip the ticket file on Full track; use inline plan instead of `CreatePlan` when Plan mode is required.
+- Skip required subagent types (use wrong type or parent agent directly when a subagent is mandated).
 - Commit without tests + `ReadLints` (for code you changed).
 - Merge on failing/unknown required CI unless the user explicitly overrides.
 - Ship roadmap-matched work without `docs/roadmap.md` update (unless deferred in ticket + user agreed).
@@ -112,4 +129,4 @@ Do **not** call `StrReplace`, `Write`, `Delete`, or implementation `Shell` until
 
 ## Project stack (reminder)
 
-Laravel 13, PHP 8.3+, DDEV, Blade, Vite 5, Tailwind 4, bilingual `resources/lang/` EN+DE. Onboarding: `README.md`.
+Laravel 13, PHP 8.3+, DDEV (MariaDB 10.4), Blade, Vite 6, Tailwind 4, bilingual `resources/lang/` EN+DE. Onboarding: `README.md`.


### PR DESCRIPTION
## Summary

Alle relevanten Workflow-Phasen bekommen verpflichtende Subagent-Anweisungen. Parallelausführung von Tests (background shell subagent) und Docs-Draft (parent agent) ist jetzt Pflicht.

## Changes

**Quick-reference:**
- Neue "Subagent map" Tabelle mit Typ, Background-Flag und Notes pro Phase
- Pre-commit gate: erwartet explizit shell-Subagent-Ergebnis
- Ordering zeigt Parallelismus: `Tests (shell bg) ‖ Docs draft (parent)`
- Violations: Subagent-Skip als harte Verletzung ergänzt

**Detail-file:**
- **Phase 1:** MUST `explore` subagent (thoroughness: medium/very thorough), await vor Phase 2
- **Phase 5:** `best-of-n-runner` nur bei echter arch. Unsicherheit
- **Phase 6:** MUST `shell` subagent background; parent läuft Phase 8 parallel
- **Phase 7:** kein dedizierter Subagent — `ReadLints` im parent
- **Phase 8:** parent parallel zu Phase 6 shell subagent
- **Phase 9:** MUST `generalPurpose` subagent für UI-Verifikation
- **Phase 12/13:** MUST `shell` subagent für PR + CI + Merge
- Plan-trigger 5 → 8 Dateien (Fix aus vorherigem PR)
- Pint-Referenzen vollständig entfernt

## Roadmap: N/A
## Public copy: N/A

Made with [Cursor](https://cursor.com)