### PR TITLE
feat: anti-repeat / fairness option for shuffle wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
+- **Anti-repeat / fairness option:** Logged-in users can tick **"Avoid recently played factions"** in the shuffle wizard (step 1) to exclude factions seen in their last 5 shuffles (configurable via `SHUFFLE_ANTI_REPEAT_WINDOW`). **Quick shuffle (`/random`)** applies anti-repeat automatically for logged-in users. Soft fallback: when the filtered pool is too small, the full pool is used and a notice is shown on the result screen. Guests see the option greyed out with a sign-in hint. New lang keys `shuffle_avoid_recent_*` + `shuffle_anti_repeat_fallback` (EN + DE).
+
 - **GitHub automation:** **Dependabot** (`.github/dependabot.yml`) opens weekly update PRs for **Composer**, **npm**, and **GitHub Actions**. **CI** runs **`composer audit`** and **`./vendor/bin/pint --test`** after `composer install`. **`laravel/pint`** is a Composer **dev** dependency; PHP style is normalized project-wide to match Pint defaults.
 
 - **Landing hero demo:** The marketing carousel is labeled as **preview-only** (bilingual badge + hint), uses a clearer `aria-label`, and decorative tiles/chips use `pointer-events-none` so they do not feel clickable. **Shuffle wizard:** In-modal **toast** when include/exclude leaves no factions or too few for the player count; **server-side** distinct flash messages for include/exclude conflict vs. empty pool. **Faction detail:** `.deck-html` spacing and list typography improved for long descriptions (EN/DE strings where new).

--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -98,11 +98,22 @@ class DeckController extends Controller
 
     /**
      * Quick-shuffle two players using the eligible faction pool (respects logged-in user's collection).
+     * Anti-repeat is applied automatically for logged-in users; falls back to the full pool when the
+     * filtered pool is too small.
      */
     public function quickShuffle(Request $request): View
     {
         $user = $request->user();
-        $decks = $this->shufflePool->eligibleDecks($user, [], [])->shuffle();
+        $antiRepeatFallback = false;
+
+        $decks = $this->shufflePool->eligibleDecks($user, [], [], avoidRecent: $user !== null);
+
+        if ($user !== null && $decks->count() < 4) {
+            $decks = $this->shufflePool->eligibleDecks($user, [], []);
+            $antiRepeatFallback = true;
+        }
+
+        $decks = $decks->shuffle();
         $selectedDecks = [];
 
         for ($i = 0; $i < 2; $i++) {
@@ -130,6 +141,7 @@ class DeckController extends Controller
             'sharePublicId' => $share->public_id,
             'sharePlainText' => SharedShuffleResult::plainTextSummary($selectedDecks),
             'metaRobots' => 'index, follow',
+            'antiRepeatFallback' => $antiRepeatFallback,
         ]);
     }
 
@@ -147,7 +159,16 @@ class DeckController extends Controller
         }
 
         $user = $request->user();
-        $decks = $this->shufflePool->eligibleDecks($user, $includedFactions, $excludedFactions);
+        $avoidRecent = $user !== null && $request->boolean('avoidRecent');
+        $antiRepeatFallback = false;
+
+        $decks = $this->shufflePool->eligibleDecks($user, $includedFactions, $excludedFactions, $avoidRecent);
+
+        // Soft fallback: if anti-repeat shrinks the pool below minimum, retry without it.
+        if ($avoidRecent && $decks->count() < $numberOfPlayers * 2) {
+            $decks = $this->shufflePool->eligibleDecks($user, $includedFactions, $excludedFactions);
+            $antiRepeatFallback = true;
+        }
 
         if ($decks->isEmpty()) {
             if ($includedFactions !== [] && array_diff($includedFactions, $excludedFactions) === []) {
@@ -165,9 +186,7 @@ class DeckController extends Controller
 
         for ($i = 1; $i <= $numberOfPlayers; $i++) {
             $playerDecks = $decks->random(2);
-            $selectedDecks[] = $playerDecks->map(function ($deck) {
-                return ['name' => $deck->name];
-            })->toArray();
+            $selectedDecks[] = $playerDecks->map(fn ($deck) => ['name' => $deck->name])->toArray();
             $decks = $decks->diff($playerDecks);
         }
 
@@ -190,6 +209,7 @@ class DeckController extends Controller
             'sharePublicId' => $share->public_id,
             'sharePlainText' => SharedShuffleResult::plainTextSummary($selectedDecks),
             'metaRobots' => 'index, follow',
+            'antiRepeatFallback' => $antiRepeatFallback,
         ]);
     }
 }

--- a/app/Services/ShuffleDeckPool.php
+++ b/app/Services/ShuffleDeckPool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Deck;
+use App\Models\ShuffleHistory;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -28,14 +29,45 @@ class ShuffleDeckPool
     }
 
     /**
-     * Factions eligible for shuffle after include/exclude (faction names) are applied.
+     * Faction names played in the user's most recent history rows.
+     *
+     * @param  positive-int  $window  Number of history rows to inspect
+     * @return list<string>
+     */
+    public function recentFactionNames(?User $user, int $window): array
+    {
+        if ($user === null) {
+            return [];
+        }
+
+        return $user->shuffleHistories()
+            ->orderByDesc('created_at')
+            ->limit($window)
+            ->get()
+            ->flatMap(
+                fn (ShuffleHistory $history) => collect($history->results)
+                    ->flatten(1)
+                    ->pluck('name')
+            )
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Factions eligible for shuffle after include/exclude and optional anti-repeat filters.
      *
      * @param  list<string>  $includedFactions
      * @param  list<string>  $excludedFactions
+     * @param  bool  $avoidRecent  Exclude faction names from the user's recent history
      * @return Collection<int, Deck>
      */
-    public function eligibleDecks(?User $user, array $includedFactions, array $excludedFactions): Collection
-    {
+    public function eligibleDecks(
+        ?User $user,
+        array $includedFactions,
+        array $excludedFactions,
+        bool $avoidRecent = false,
+    ): Collection {
         $query = $this->baseQuery($user);
 
         if ($includedFactions !== []) {
@@ -44,6 +76,13 @@ class ShuffleDeckPool
 
         if ($excludedFactions !== []) {
             $query->whereNotIn('name', $excludedFactions);
+        }
+
+        if ($avoidRecent) {
+            $recent = $this->recentFactionNames($user, config('shuffle.anti_repeat_window', 5));
+            if ($recent !== []) {
+                $query->whereNotIn('name', $recent);
+            }
         }
 
         return $query->get();

--- a/config/shuffle.php
+++ b/config/shuffle.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    /*
+     * Number of recent shuffle history rows to inspect when the anti-repeat
+     * fairness option is active. Each row covers one full game (2–4 players
+     * × 2 factions), so the default of 5 typically excludes 10–20 factions.
+     */
+    'anti_repeat_window' => (int) env('SHUFFLE_ANTI_REPEAT_WINDOW', 5),
+];

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,7 +34,7 @@ Backlog from product discussion (2026-04-19). **Suggested pick order:** near-ter
 
 ### Near-term (high impact, manageable scope)
 
-- **Anti-repeat / fairness option** — Optionally exclude or downweight faction combos that appear in recent **play history** (logged-in users); configurable window or count; tests for edge cases (small pools, presets).
+- **Anti-repeat / fairness option** ✅ — "Avoid recently played factions" checkbox in shuffle wizard (step 1); auto-applied for logged-in users on quick shuffle. Soft fallback when pool too small. Configurable window (`SHUFFLE_ANTI_REPEAT_WINDOW`, default 5). Guests see greyed-out hint.
 - **History actions** — Repeat a past shuffle, or **spawn a preset** from a history row (reuses existing presets + `shuffle_histories`).
 - **Print-friendly result view** — Dedicated Blade route/layout for a clean table printout (optional: browser PDF via print CSS).
 - **Shuffle `<dialog>` accessibility** — Keyboard, focus management / trap, and screen reader labels for the home shuffle wizard (`<dialog>` stepper).

--- a/docs/tickets/2026-06-20-anti-repeat-fairness-option.md
+++ b/docs/tickets/2026-06-20-anti-repeat-fairness-option.md
@@ -1,0 +1,48 @@
+## Anti-repeat / Fairness Option (History-based)
+
+## Summary
+Add an opt-in "Avoid recently played factions" toggle to the shuffle wizard (and quick shuffle) that excludes faction names already seen in the user's recent play history from the eligible pool, reducing repetition across consecutive games.
+
+## Background / Context
+
+- **Current behavior:** Every shuffle draws from the full eligible pool (optionally constrained by collection/include/exclude), with no memory of past results. Repeat factions appear frequently when the pool is small.
+- **Domain context:** Only logged-in users have `shuffle_histories`. Guests will see the UI hint but the option is effectively a no-op (no history to exclude from).
+- **Pattern to mirror:** `ShuffleDeckPool::eligibleDecks` already filters by collection ownership and include/exclude lists — anti-repeat fits as a third filter layer using the same service.
+- **History data:** `shuffle_histories.results` stores faction **names** as nested JSON — directly usable for `whereNotIn('name', ...)` on `Deck`.
+
+**User story:** As a logged-in player, I want the randomizer to avoid factions I've played recently, so each session feels fresh.
+
+## Requirements
+
+- [ ] Wizard shows an "Avoid recently played" checkbox (step 1 or below player-count radios); visible to all, greyed-out / tooltip for guests
+- [ ] `ShuffleDeckPool` gains a method to resolve recently-played faction names from history (last N shuffles, window configurable via `config/shuffle.php` or default constant)
+- [ ] `POST /shuffle/result` and `GET /random` respect the flag when provided (auth users only; guests: ignore silently)
+- [ ] **Soft fallback:** if anti-repeat exclusion shrinks the pool below the required minimum, retry without anti-repeat and surface a flash message / UI note explaining the fallback
+- [ ] Quick shuffle (`/random`) applies anti-repeat automatically for logged-in users without a UI toggle (always-on since there is no wizard)
+- [ ] EN + DE lang keys for all new visible strings
+- [ ] No DB migration (feature is per-shuffle toggle, not a stored preference)
+
+## Technical notes
+
+- **Affected areas:** `app/Services/ShuffleDeckPool.php`, `app/Http/Controllers/DeckController.php`, `resources/views/start/home.blade.php`, `resources/lang/en/`, `resources/lang/de/`, `config/shuffle.php` (new or existing config file for window constant)
+- **Approach:** add `recentFactionNames(?User $user, int $window): array` to `ShuffleDeckPool`; update `eligibleDecks` signature or add a thin wrapper; both controller endpoints pass the flag
+- **Plan mode:** skipped — no migration, no new route, no new dependency, no arch fork; mirrors exact `ShuffleDeckPool` collection-filter pattern
+- **Window default:** 5 most recent shuffle history rows (covers ~10–20 factions) — configurable via `config('shuffle.anti_repeat_window', 5)`
+- **Edge case — small pools:** use a two-pass approach: attempt with anti-repeat; if `count($pool) < $players * 2`, fall back to full pool + flash warning `shuffle_anti_repeat_fallback`
+
+## Testing
+
+- **PHPUnit Feature:** `tests/Feature/Shuffle/AntiRepeatTest.php` (new):
+  - Logged-in user with history: anti-repeat excludes recent names from drawn factions
+  - Logged-in user, pool too small after exclusion: fallback to full pool, flash message present
+  - Guest: anti-repeat flag ignored, shuffle proceeds normally
+  - Empty history: anti-repeat no-op, same as normal shuffle
+  - Quick shuffle (GET /random) with history: recent factions excluded
+- **Manual / browser:** wizard checkbox visible, greyed for guest; successful shuffle with and without checked; fallback flash on tiny pool
+
+## Impact / Risks
+
+- **Performance:** history query is at most `config('shuffle.anti_repeat_window')` rows — negligible
+- **Regression:** soft fallback ensures existing pool-too-small error path is not duplicated; existing tests stay green
+- **Guests:** feature is auth-scoped; no change to guest shuffle behavior
+- **Presets:** presets do not store anti-repeat flag — that is a separate backlog item if needed

--- a/resources/lang/de/frontend.php
+++ b/resources/lang/de/frontend.php
@@ -440,4 +440,10 @@ return [
     'email_field_timestamp' => 'Zeitstempel',
     'email_field_application' => 'Anwendung',
     'email_test_ok' => 'Wenn du das hier lesen kannst, funktioniert deine Mail-Konfiguration.',
+
+    // Anti-Repeat / Fairness-Option
+    'shuffle_avoid_recent_label' => 'Zuletzt gespielte Fraktionen vermeiden',
+    'shuffle_avoid_recent_hint' => 'Überspringt Fraktionen aus deinen letzten :window Shuffles — ideal für mehrere Spiele hintereinander.',
+    'shuffle_avoid_recent_guest_hint' => 'Anmelden erforderlich — braucht Spielverlauf.',
+    'shuffle_anti_repeat_fallback' => 'Nicht genug neue Fraktionen, um den Verlauf vollständig zu vermeiden — vollständiger Pool wurde verwendet.',
 ];

--- a/resources/lang/en/frontend.php
+++ b/resources/lang/en/frontend.php
@@ -375,6 +375,12 @@ return [
     'shuffle_error_pool_empty' => 'No factions left: adjust include or exclude (for example, do not exclude the entire list).',
     'shuffle_error_not_enough_factions' => 'Not enough factions in the pool for the selected player count (each player needs two factions).',
 
+    // Anti-repeat / fairness option
+    'shuffle_avoid_recent_label' => 'Avoid recently played factions',
+    'shuffle_avoid_recent_hint' => 'Skips factions from your last :window shuffles — great for back-to-back games.',
+    'shuffle_avoid_recent_guest_hint' => 'Sign in to use this — requires play history.',
+    'shuffle_anti_repeat_fallback' => 'Not enough new factions to fully avoid recent history — used the complete pool instead.',
+
     // Account — edit page
     'account_edit_page_heading' => 'Edit account',
     'account_edit_page_sub' => 'Update your display name, e-mail address, and password.',

--- a/resources/views/shuffle/shuffle-decks.blade.php
+++ b/resources/views/shuffle/shuffle-decks.blade.php
@@ -50,6 +50,18 @@
         </x-sur.container>
     </section>
 
+    {{-- Anti-repeat fallback notice --}}
+    @if($antiRepeatFallback ?? false)
+        <div class="border-b border-amber-500/20 bg-amber-950/30 px-4 py-3">
+            <x-sur.container>
+                <p class="flex items-center gap-2 text-xs leading-relaxed text-amber-300">
+                    <i class="fa-solid fa-circle-info shrink-0" aria-hidden="true"></i>
+                    {{ __('frontend.shuffle_anti_repeat_fallback') }}
+                </p>
+            </x-sur.container>
+        </div>
+    @endif
+
     {{-- Results grid --}}
     <x-sur.section>
         <x-sur.container>

--- a/resources/views/start/home.blade.php
+++ b/resources/views/start/home.blade.php
@@ -668,6 +668,35 @@
                                 @endforeach
                             </div>
                         </fieldset>
+
+                        {{-- Anti-repeat / fairness option --}}
+                        @auth
+                            <label class="mt-4 flex cursor-pointer items-start gap-3 rounded-xl border border-white/10 bg-zinc-900/40 px-4 py-3 transition hover:border-indigo-500/30 hover:bg-zinc-800/60 has-[:checked]:border-indigo-500/50 has-[:checked]:bg-indigo-950/30">
+                                <input
+                                    type="checkbox"
+                                    name="avoidRecent"
+                                    value="1"
+                                    id="avoidRecentCheck"
+                                    class="mt-0.5 h-4 w-4 shrink-0 accent-indigo-500"
+                                >
+                                <div class="min-w-0">
+                                    <span class="block text-sm font-medium text-zinc-200">{{ __('frontend.shuffle_avoid_recent_label') }}</span>
+                                    <span class="block text-xs leading-relaxed text-zinc-500">{{ __('frontend.shuffle_avoid_recent_hint', ['window' => config('shuffle.anti_repeat_window', 5)]) }}</span>
+                                </div>
+                            </label>
+                        @else
+                            <div
+                                class="mt-4 flex cursor-not-allowed items-start gap-3 rounded-xl border border-white/8 bg-zinc-900/25 px-4 py-3 opacity-50"
+                                title="{{ __('frontend.shuffle_avoid_recent_guest_hint') }}"
+                                aria-disabled="true"
+                            >
+                                <div class="mt-0.5 h-4 w-4 shrink-0 rounded border border-white/20 bg-zinc-800"></div>
+                                <div class="min-w-0">
+                                    <span class="block text-sm font-medium text-zinc-200">{{ __('frontend.shuffle_avoid_recent_label') }}</span>
+                                    <span class="block text-xs leading-relaxed text-zinc-500">{{ __('frontend.shuffle_avoid_recent_guest_hint') }}</span>
+                                </div>
+                            </div>
+                        @endauth
                     </div>
 
                     <div class="shuffle-step-content hidden" id="step2-content">

--- a/tests/Feature/Shuffle/AntiRepeatTest.php
+++ b/tests/Feature/Shuffle/AntiRepeatTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Shuffle;
+
+use App\Models\Deck;
+use App\Models\ShuffleHistory;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AntiRepeatTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Seed N factions with optional expansion label.
+     *
+     * @param  list<string>  $names
+     */
+    private function seedFactions(array $names, string $expansion = 'Core'): void
+    {
+        foreach ($names as $name) {
+            Deck::query()->create(['name' => $name, 'expansion' => $expansion]);
+        }
+    }
+
+    /**
+     * Write a shuffle history row for a user (2 players, 2 factions each).
+     *
+     * @param  list<string>  $factionNames  Exactly 4 names (player1×2, player2×2)
+     */
+    private function seedHistory(User $user, array $factionNames): void
+    {
+        ShuffleHistory::query()->create([
+            'user_id' => $user->id,
+            'player_count' => 2,
+            'results' => [
+                [['name' => $factionNames[0]], ['name' => $factionNames[1]]],
+                [['name' => $factionNames[2]], ['name' => $factionNames[3]]],
+            ],
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Wizard POST (POST /shuffle/result)
+    // -----------------------------------------------------------------------
+
+    public function test_wizard_anti_repeat_excludes_recent_factions_from_result(): void
+    {
+        // 8 factions available; 4 were played recently
+        $this->seedFactions(['Old1', 'Old2', 'Old3', 'Old4', 'New1', 'New2', 'New3', 'New4']);
+
+        $user = User::factory()->create();
+        $this->seedHistory($user, ['Old1', 'Old2', 'Old3', 'Old4']);
+
+        $response = $this->actingAs($user)->post(route('shuffle-result'), [
+            'numberOfPlayers' => '2',
+            'avoidRecent' => '1',
+        ]);
+
+        $response->assertOk();
+        $response->assertViewIs('shuffle.shuffle-decks');
+
+        $drawn = collect($response->viewData('selectedDecks'))
+            ->flatten(1)
+            ->pluck('name')
+            ->all();
+
+        foreach ($drawn as $name) {
+            $this->assertStringStartsWith('New', $name, "Recent faction [{$name}] should not appear when anti-repeat is active");
+        }
+    }
+
+    public function test_wizard_anti_repeat_fallback_when_pool_too_small(): void
+    {
+        // Only 4 factions; all 4 in recent history → anti-repeat would leave 0
+        $this->seedFactions(['A', 'B', 'C', 'D']);
+
+        $user = User::factory()->create();
+        $this->seedHistory($user, ['A', 'B', 'C', 'D']);
+
+        $response = $this->actingAs($user)->post(route('shuffle-result'), [
+            'numberOfPlayers' => '2',
+            'avoidRecent' => '1',
+        ]);
+
+        $response->assertOk();
+        // Fallback engaged: view receives antiRepeatFallback = true
+        $this->assertTrue($response->viewData('antiRepeatFallback'), 'Fallback flag should be set when anti-repeat empties the pool');
+        // Shuffle still produces a valid result
+        $this->assertCount(2, $response->viewData('selectedDecks'));
+    }
+
+    public function test_wizard_anti_repeat_no_op_for_guest_even_with_flag(): void
+    {
+        // Guests have no history — avoidRecent flag should be silently ignored
+        $this->seedFactions(['A', 'B', 'C', 'D']);
+
+        $response = $this->post(route('shuffle-result'), [
+            'numberOfPlayers' => '2',
+            'avoidRecent' => '1',
+        ]);
+
+        $response->assertOk();
+        $this->assertFalse($response->viewData('antiRepeatFallback'));
+    }
+
+    public function test_wizard_anti_repeat_no_op_with_empty_history(): void
+    {
+        $this->seedFactions(['A', 'B', 'C', 'D']);
+
+        $user = User::factory()->create();
+        // No history rows created
+
+        $response = $this->actingAs($user)->post(route('shuffle-result'), [
+            'numberOfPlayers' => '2',
+            'avoidRecent' => '1',
+        ]);
+
+        $response->assertOk();
+        $this->assertFalse($response->viewData('antiRepeatFallback'));
+        $this->assertCount(2, $response->viewData('selectedDecks'));
+    }
+
+    public function test_wizard_without_flag_does_not_restrict_recent_factions(): void
+    {
+        // With flag off, even recently-played factions can be drawn
+        $this->seedFactions(['A', 'B', 'C', 'D']);
+
+        $user = User::factory()->create();
+        $this->seedHistory($user, ['A', 'B', 'C', 'D']);
+
+        $response = $this->actingAs($user)->post(route('shuffle-result'), [
+            'numberOfPlayers' => '2',
+            // avoidRecent not sent
+        ]);
+
+        $response->assertOk();
+        $this->assertFalse($response->viewData('antiRepeatFallback'));
+        $this->assertCount(2, $response->viewData('selectedDecks'));
+    }
+
+    // -----------------------------------------------------------------------
+    // Quick shuffle (GET /random)
+    // -----------------------------------------------------------------------
+
+    public function test_quick_shuffle_auto_applies_anti_repeat_for_logged_in_user(): void
+    {
+        // 8 factions; 4 recent
+        $this->seedFactions(['Old1', 'Old2', 'Old3', 'Old4', 'New1', 'New2', 'New3', 'New4']);
+
+        $user = User::factory()->create();
+        $this->seedHistory($user, ['Old1', 'Old2', 'Old3', 'Old4']);
+
+        $response = $this->actingAs($user)->get(route('random'));
+
+        $response->assertOk();
+
+        $drawn = collect($response->viewData('selectedDecks'))
+            ->flatten(1)
+            ->pluck('name')
+            ->all();
+
+        foreach ($drawn as $name) {
+            $this->assertStringStartsWith('New', $name, "Recent faction [{$name}] should not appear in quick shuffle");
+        }
+    }
+
+    public function test_quick_shuffle_falls_back_to_full_pool_when_anti_repeat_leaves_too_few(): void
+    {
+        // Only 4 factions, all played recently
+        $this->seedFactions(['A', 'B', 'C', 'D']);
+
+        $user = User::factory()->create();
+        $this->seedHistory($user, ['A', 'B', 'C', 'D']);
+
+        $response = $this->actingAs($user)->get(route('random'));
+
+        $response->assertOk();
+        $this->assertTrue($response->viewData('antiRepeatFallback'));
+        $this->assertCount(2, $response->viewData('selectedDecks'));
+    }
+
+    public function test_quick_shuffle_guest_has_no_anti_repeat(): void
+    {
+        $this->seedFactions(['A', 'B', 'C', 'D']);
+
+        $response = $this->get(route('random'));
+
+        $response->assertOk();
+        $this->assertFalse($response->viewData('antiRepeatFallback'));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **"Avoid recently played factions"** checkbox to shuffle wizard step 1 (auth users only; greyed out for guests with sign-in hint)
- **Quick shuffle** (`/random`) auto-applies anti-repeat for logged-in users
- **Soft fallback:** if anti-repeat leaves the pool too small, falls back to full pool silently + shows an info notice on the result screen
- Configurable history window via `SHUFFLE_ANTI_REPEAT_WINDOW` env (default 5 shuffles)
- 8 new feature tests — all 190 tests green

## Test plan

- [ ] Guest: wizard step 1 shows greyed-out anti-repeat option, shuffle works normally
- [ ] Auth user with history: tick checkbox → recently-played factions not in result
- [ ] Auth user, tiny pool (history covers all factions): fallback notice appears, shuffle still succeeds
- [ ] `/random` logged in with history: recent factions excluded automatically
- [ ] `php artisan test` — 190 passed, 0 failed

## Related

Closes roadmap item: Anti-repeat / fairness option
Ticket: `docs/tickets/2026-06-20-anti-repeat-fairness-option.md`

Made with [Cursor](https://cursor.com)