### PR TITLE
chore: harden GitHub repository configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        # Fail if overall project coverage drops more than 2%
+        threshold: 2%
+        target: auto
+    patch:
+      default:
+        # New code in a PR must be at least 70% covered
+        target: 70%
+        threshold: 5%
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,29 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      laravel:
+        patterns:
+          - "laravel/*"
+      symfony:
+        patterns:
+          - "symfony/*"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+<!-- What changed and why? 1–3 bullets. -->
+-
+
+## Type
+<!-- Delete all that do not apply -->
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Chore / refactor
+- [ ] Docs
+
+## Checklist
+- [ ] Tests added / updated and passing (`ddev exec php artisan test`)
+- [ ] Pint style clean (`ddev exec ./vendor/bin/pint --test`)
+- [ ] `composer audit` — no new critical/high CVEs
+- [ ] Migration rollback tested (`migrate:rollback && migrate`) — if applicable
+- [ ] `.env.example` updated — if new env vars introduced
+- [ ] `lang:check` clean — if `resources/lang/` changed
+- [ ] EN + DE strings added for all user-visible copy
+
+## Roadmap
+<!-- Did this implement or advance a roadmap item? Link or write "N/A". -->
+N/A
+
+## Public copy
+<!-- CHANGELOG [Unreleased] updated? Lang keys added? Or write "N/A". -->
+N/A

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint & Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Composer audit
+        run: composer audit
+
+      - name: Laravel Pint (style)
+        run: ./vendor/bin/pint --test
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: npm audit
+        run: npm audit --audit-level=high
+
   test:
+    name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -47,12 +97,6 @@ jobs:
 
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
-
-      - name: Composer audit
-        run: composer audit
-
-      - name: Laravel Pint (style)
-        run: ./vendor/bin/pint --test
 
       - name: Prepare environment
         run: cp .env.example .env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Extract the section between this version header and the next
+          BODY=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          if [ -z "$BODY" ]; then
+            BODY="See [CHANGELOG.md](CHANGELOG.md) for details."
+          fi
+          # Write to file to preserve newlines
+          echo "$BODY" > release_notes.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release_notes.txt
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/docs/tickets/2026-06-23-github-hardening.md
+++ b/docs/tickets/2026-06-23-github-hardening.md
@@ -1,0 +1,36 @@
+# Harden GitHub repository configuration
+
+## Summary
+Extend the existing CI/CD and repository configuration to enforce branch protection,
+surface security issues faster, reduce Dependabot noise, and automate releases.
+
+## Background / Context
+- Current CI is a single sequential job; no branch protection on `master`; no PR template
+- `npm audit` is missing from CI (only `composer audit` runs)
+- Dependabot opens individual PRs per package (high noise)
+- No release automation when `master` is tagged
+- Codecov is integrated but no coverage threshold enforcement
+
+## Requirements
+- [ ] Branch protection on `master`: require PR + CI pass + no force push
+- [ ] Add `npm audit --audit-level=high` to CI after `npm ci`
+- [ ] PR template at `.github/pull_request_template.md` (Roadmap + Public copy sections)
+- [ ] Dependabot grouped updates for `laravel/*`, `symfony/*`, and npm devDependencies
+- [ ] Release workflow: on `v*.*.*` tag, create GitHub Release from CHANGELOG
+- [ ] Split CI into parallel `lint` and `test` jobs for faster feedback
+- [ ] `.codecov.yml` with coverage threshold (fail PR if coverage drops >2%)
+
+## Technical notes
+- Plan: skipped — no migration, route, >8 files, dependency, or arch fork
+- Affected: `.github/workflows/ci.yml`, `.github/dependabot.yml`, new `.github/workflows/release.yml`, new `.github/pull_request_template.md`, new `.codecov.yml`
+- Branch protection via `gh api repos/{owner}/{repo}/branches/master/protection`
+- CI parallelization: `lint` job (Pint + composer audit) runs in parallel with `test` job; PHP tests still depend on Vite build so `test` job remains sequential internally
+
+## Testing
+- **CI:** Push branch, verify two parallel jobs appear in GitHub Actions
+- **Manual:** Open a draft PR and verify the PR template loads
+
+## Impact / Risks
+- Branch protection blocks direct pushes to `master` — intended
+- Coverage threshold may initially fail if current coverage is below the floor; check before setting the threshold
+- `npm audit` may surface existing advisories — `--audit-level=high` limits to high/critical only


### PR DESCRIPTION
## Summary
- Split CI into parallel `lint` + `test` jobs; adds `npm audit --audit-level=high`
- PR template enforcing workflow checklist (Roadmap, Public copy, lang:check, etc.)
- Dependabot grouped updates (laravel/\*, symfony/\*, actions, npm dev deps)
- Release workflow triggered on `v*.*.*` tags, extracts CHANGELOG section
- `.codecov.yml`: 2% project threshold, 70% patch target
- Branch protection on `master`: require `lint` + `test` CI, PR required, no force push

## Roadmap
N/A

## Public copy
N/A

Made with [Cursor](https://cursor.com)