### PR TITLE
chore(deps): bump postcss and immutable for npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "alpinejs": "^3.15.11",
                 "autoprefixer": "^10.4.2",
                 "laravel-vite-plugin": "^1.0.1",
-                "postcss": "^8.4.6",
+                "postcss": "^8.5.18",
                 "rollup": "^4.60.1",
                 "tailwindcss": "^4.1.0",
                 "vite": "^6.4.3"
@@ -1928,9 +1928,9 @@
             "license": "ISC"
         },
         "node_modules/immutable": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -2303,9 +2303,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.13",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-            "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -2361,9 +2361,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.25",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+            "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
             "dev": true,
             "funding": [
                 {
@@ -2381,7 +2381,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "overrides": {
-        "immutable": "5.1.5"
+        "immutable": "5.1.9"
     },
     "scripts": {
         "dev": "vite",
@@ -12,7 +12,7 @@
         "alpinejs": "^3.15.11",
         "autoprefixer": "^10.4.2",
         "laravel-vite-plugin": "^1.0.1",
-        "postcss": "^8.4.6",
+        "postcss": "^8.5.18",
         "rollup": "^4.60.1",
         "tailwindcss": "^4.1.0",
         "vite": "^6.4.3"


### PR DESCRIPTION
## Summary
- Bump `postcss` to `^8.5.18` (lock: 8.5.25) — fixes GHSA-r28c-9q8g-f849 (high)
- Raise `overrides.immutable` to `5.1.9` — fixes GHSA-v56q-mh7h-f735 / GHSA-xvcm-6775-5m9r (high)
- Unblocks Dependabot PRs currently failing `npm audit --audit-level=high`

## Test plan
- [x] `ddev npm audit --audit-level=high` → 0 vulnerabilities
- [ ] CI Lint & Audit + Tests green

Made with [Cursor](https://cursor.com)